### PR TITLE
Improves converter speed

### DIFF
--- a/src/utilities/sbgnml-to-json-converter.js
+++ b/src/utilities/sbgnml-to-json-converter.js
@@ -1,26 +1,31 @@
 var elementUtilities = require('./element-utilities');
-var libs = require('./lib-utilities').getLibs();
-var jQuery = $ = libs.jQuery;
 
 var sbgnmlToJson = {
   insertedNodes: {},
   getAllCompartments: function (xmlObject) {
     var compartments = [];
-    $(xmlObject).find("glyph[class='compartment']").each(function () {
+
+    var compartmentEls = xmlObject.querySelectorAll("glyph[class='compartment']");
+
+    for (var i = 0; i < compartmentEls.length; i++) {
+      var compartment = compartmentEls[i];
+      var bbox = this.findChildNode(compartment, 'bbox');
       compartments.push({
-        'x': parseFloat($(this).children('bbox').attr('x')),
-        'y': parseFloat($(this).children('bbox').attr('y')),
-        'w': parseFloat($(this).children('bbox').attr('w')),
-        'h': parseFloat($(this).children('bbox').attr('h')),
-        'id': $(this).attr('id')
+        'x': parseFloat(bbox.getAttribute('x')),
+        'y': parseFloat(bbox.getAttribute('y')),
+        'w': parseFloat(bbox.getAttribute('w')),
+        'h': parseFloat(bbox.getAttribute('h')),
+        'id': compartment.getAttribute('id')
       });
-    });
+    }
 
     compartments.sort(function (c1, c2) {
-      if (c1.h * c1.w < c2.h * c2.w)
+      if (c1.h * c1.w < c2.h * c2.w) {
         return -1;
-      if (c1.h * c1.w > c2.h * c2.w)
+      }
+      if (c1.h * c1.w > c2.h * c2.w) {
         return 1;
+      }
       return 0;
     });
 
@@ -30,19 +35,20 @@ var sbgnmlToJson = {
     if (bbox1.x > bbox2.x &&
         bbox1.y > bbox2.y &&
         bbox1.x + bbox1.w < bbox2.x + bbox2.w &&
-        bbox1.y + bbox1.h < bbox2.y + bbox2.h)
+        bbox1.y + bbox1.h < bbox2.y + bbox2.h) {
       return true;
+    }
     return false;
   },
   bboxProp: function (ele) {
-    var sbgnbbox = new Object();
+    var sbgnbbox = {};
+    var bbox = ele.querySelector('bbox');
 
-    sbgnbbox.x = $(ele).find('bbox').attr('x');
-    sbgnbbox.y = $(ele).find('bbox').attr('y');
-    sbgnbbox.w = $(ele).find('bbox').attr('w');
-    sbgnbbox.h = $(ele).find('bbox').attr('h');
-
-    //set positions as center
+    sbgnbbox.x = bbox.getAttribute('x');
+    sbgnbbox.y = bbox.getAttribute('y');
+    sbgnbbox.w = bbox.getAttribute('w');
+    sbgnbbox.h = bbox.getAttribute('h');
+    // set positions as center
     sbgnbbox.x = parseFloat(sbgnbbox.x) + parseFloat(sbgnbbox.w) / 2;
     sbgnbbox.y = parseFloat(sbgnbbox.y) + parseFloat(sbgnbbox.h) / 2;
 
@@ -52,14 +58,15 @@ var sbgnmlToJson = {
     var xPos = parseFloat(parentBbox.x);
     var yPos = parseFloat(parentBbox.y);
 
-    var sbgnbbox = new Object();
+    var sbgnbbox = {};
+    var bbox = ele.querySelector('bbox');
 
-    sbgnbbox.x = $(ele).find('bbox').attr('x');
-    sbgnbbox.y = $(ele).find('bbox').attr('y');
-    sbgnbbox.w = $(ele).find('bbox').attr('w');
-    sbgnbbox.h = $(ele).find('bbox').attr('h');
+    sbgnbbox.x = bbox.getAttribute('x');
+    sbgnbbox.y = bbox.getAttribute('y');
+    sbgnbbox.w = bbox.getAttribute('w');
+    sbgnbbox.h = bbox.getAttribute('h');
 
-    //set positions as center
+    // set positions as center
     sbgnbbox.x = parseFloat(sbgnbbox.x) + parseFloat(sbgnbbox.w) / 2 - xPos;
     sbgnbbox.y = parseFloat(sbgnbbox.y) + parseFloat(sbgnbbox.h) / 2 - yPos;
 
@@ -68,103 +75,134 @@ var sbgnmlToJson = {
 
     return sbgnbbox;
   },
+  findChildNodes: function (ele, childTagName) {
+    // find child nodes at depth level of 1 relative to the element
+    var children = [];
+    for (var i = 0; i < ele.childNodes.length; i++) {
+      var child = ele.childNodes[i];
+      if (child.nodeType === 1 && child.tagName === childTagName) {
+        children.push(child);
+      }
+    }
+    return children;
+  },
+  findChildNode: function (ele, childTagName) {
+    var nodes = this.findChildNodes(ele, childTagName);
+    return nodes.length > 0 ? nodes[0] : undefined;
+  },
   stateAndInfoProp: function (ele, parentBbox) {
     var self = this;
-    var stateAndInfoArray = new Array();
+    var stateAndInfoArray = [];
 
-    $(ele).children('glyph').each(function () {
-      var obj = new Object();
-      if ($(this).attr('class') === 'unit of information') {
-        obj.id = $(this).attr('id');
-        obj.clazz = $(this).attr('class');
-        obj.label = {'text': $(this).find('label').attr('text')};
-        obj.bbox = self.stateAndInfoBboxProp(this, parentBbox);
-        stateAndInfoArray.push(obj);
+    var childGlyphs = this.findChildNodes(ele, 'glyph');
+
+    for (var i = 0; i < childGlyphs.length; i++) {
+      var glyph = childGlyphs[i];
+      var info = {};
+
+      if (glyph.className === 'unit of information') {
+        info.id = glyph.getAttribute('id') || undefined;
+        info.clazz = glyph.className || undefined;
+        var label = glyph.querySelector('label');
+        info.label = {
+          'text': (label && label.getAttribute('text')) || undefined
+        };
+        info.bbox = self.stateAndInfoBboxProp(glyph, parentBbox);
+        stateAndInfoArray.push(info);
+      } else if (glyph.className === 'state variable') {
+        info.id = glyph.getAttribute('id') || undefined;
+        info.clazz = glyph.className || undefined;
+        var state = glyph.querySelector('state');
+        var value = (state && state.getAttribute('value')) || undefined;
+        var variable = (state && state.getAttribute('variable')) || undefined;
+        info.state = {
+          'value': value,
+          'variable': variable
+        };
+        info.bbox = self.stateAndInfoBboxProp(glyph, parentBbox);
+        stateAndInfoArray.push(info);
       }
-      else if ($(this).attr('class') === 'state variable') {
-        obj.id = $(this).attr('id');
-        obj.clazz = $(this).attr('class');
-        obj.state = {'value': $(this).find('state').attr('value'),
-          'variable': $(this).find('state').attr('variable')};
-        obj.bbox = self.stateAndInfoBboxProp(this, parentBbox);
-        stateAndInfoArray.push(obj);
-      }
-    });
+    }
+
 
     return stateAndInfoArray;
   },
   addParentInfoToNode: function (ele, nodeObj, parent, compartments) {
     var self = this;
-    //there is no complex parent
-    if (parent == "") {
-      //no compartment reference
-      if (typeof $(ele).attr('compartmentRef') === 'undefined') {
-        nodeObj.parent = "";
+    var compartmentRef = ele.getAttribute('compartmentRef');
 
-        //add compartment according to geometry
-        for (var i = 0; i < compartments.length; i++) {
-          var bbox = {
-            'x': parseFloat($(ele).children('bbox').attr('x')),
-            'y': parseFloat($(ele).children('bbox').attr('y')),
-            'w': parseFloat($(ele).children('bbox').attr('w')),
-            'h': parseFloat($(ele).children('bbox').attr('h')),
-            'id': $(ele).attr('id')
-          }
-          if (self.isInBoundingBox(bbox, compartments[i])) {
-            nodeObj.parent = compartments[i].id;
-            break;
-          }
+    if (parent) {
+      nodeObj.parent = parent;
+      return;
+    }
+
+    if (compartmentRef) {
+      nodeObj.parent = compartmentRef;
+    } else {
+      nodeObj.parent = '';
+
+      // add compartment according to geometry
+      for (var i = 0; i < compartments.length; i++) {
+        var bboxEl = self.findChildNode(ele, 'bbox');
+        var bbox = {
+          'x': parseFloat(bboxEl.getAttribute('x')),
+          'y': parseFloat(bboxEl.getAttribute('y')),
+          'w': parseFloat(bboxEl.getAttribute('w')),
+          'h': parseFloat(bboxEl.getAttribute('h')),
+          'id': ele.getAttribute('id')
+        };
+        if (self.isInBoundingBox(bbox, compartments[i])) {
+          nodeObj.parent = compartments[i].id;
+          break;
         }
       }
-      //there is compartment reference
-      else {
-        nodeObj.parent = $(ele).attr('compartmentRef');
-      }
-    }
-    //there is complex parent
-    else {
-      nodeObj.parent = parent;
     }
   },
   addCytoscapeJsNode: function (ele, jsonArray, parent, compartments) {
     var self = this;
-    var nodeObj = new Object();
+    var nodeObj = {};
 
-    //add id information
-    nodeObj.id = $(ele).attr('id');
-    //add node bounding box information
+    // add id information
+    nodeObj.id = ele.getAttribute('id');
+    // add node bounding box information
     nodeObj.sbgnbbox = self.bboxProp(ele);
-    //add class information
-    nodeObj.sbgnclass = $(ele).attr('class');
-    //add label information
-    nodeObj.sbgnlabel = $(ele).children('label').attr('text');
-    //add state and info box information
+    // add class information
+    nodeObj.sbgnclass = ele.className;
+    // add label information
+    var label = self.findChildNode(ele, 'label');
+    nodeObj.sbgnlabel = (label && label.getAttribute('text')) || undefined;
+    // add state and info box information
     nodeObj.sbgnstatesandinfos = self.stateAndInfoProp(ele, nodeObj.sbgnbbox);
-    //adding parent information
+    // adding parent information
     self.addParentInfoToNode(ele, nodeObj, parent, compartments);
 
-    //add clone information
-    if ($(ele).children('clone').length > 0)
+    // add clone information
+    var cloneMarkers = self.findChildNodes(ele, 'clone');
+    if (cloneMarkers.length > 0) {
       nodeObj.sbgnclonemarker = true;
-    else
+    } else {
       nodeObj.sbgnclonemarker = undefined;
+    }
 
-    //add port information
+    // add port information
     var ports = [];
-    $(ele).find('port').each(function () {
-      var id = $(this).attr('id');
-      var relativeXPos = parseFloat($(this).attr('x')) - nodeObj.sbgnbbox.x;
-      var relativeYPos = parseFloat($(this).attr('y')) - nodeObj.sbgnbbox.y;
-      
+    var portElements = ele.querySelectorAll('port');
+
+    for (var i = 0; i < portElements.length; i++) {
+      var portEl = portElements[i];
+      var id = portEl.getAttribute('id');
+      var relativeXPos = parseFloat(portEl.getAttribute('x')) - nodeObj.sbgnbbox.x;
+      var relativeYPos = parseFloat(portEl.getAttribute('y')) - nodeObj.sbgnbbox.y;
+
       relativeXPos = relativeXPos / parseFloat(nodeObj.sbgnbbox.w) * 100;
       relativeYPos = relativeYPos / parseFloat(nodeObj.sbgnbbox.h) * 100;
-      
+
       ports.push({
-        id: $(this).attr('id'),
+        id: id,
         x: relativeXPos,
         y: relativeYPos
       });
-    });
+    }
 
     nodeObj.ports = ports;
 
@@ -172,112 +210,154 @@ var sbgnmlToJson = {
     jsonArray.push(cytoscapeJsNode);
   },
   traverseNodes: function (ele, jsonArray, parent, compartments) {
-    if (!elementUtilities.handledElements[$(ele).attr('class')]) {
+    var elId = ele.getAttribute('id');
+    if (!elementUtilities.handledElements[ele.className]) {
       return;
     }
-    this.insertedNodes[$(ele).attr('id')] = true;
+    this.insertedNodes[elId] = true;
     var self = this;
-    //add complex nodes here
-    if ($(ele).attr('class') === 'complex' || $(ele).attr('class') === 'submap') {
+    // add complex nodes here
+
+    var eleClass = ele.className;
+
+    if (eleClass === 'complex' || eleClass === 'submap') {
       self.addCytoscapeJsNode(ele, jsonArray, parent, compartments);
 
-      $(ele).children('glyph').each(function () {
-        if ($(this).attr('class') != 'state variable' &&
-            $(this).attr('class') != 'unit of information') {
-          self.traverseNodes(this, jsonArray, $(ele).attr('id'), compartments);
+      var childGlyphs = self.findChildNodes(ele, 'glyph');
+      for (var i = 0; i < childGlyphs.length; i++) {
+        var glyph = childGlyphs[i];
+        var glyphClass = glyph.className;
+        if (glyphClass !== 'state variable' && glyphClass !== 'unit of information') {
+          self.traverseNodes(glyph, jsonArray, elId, compartments);
         }
-      });
-    }
-    else {
+      }
+    } else {
       self.addCytoscapeJsNode(ele, jsonArray, parent, compartments);
     }
   },
-  getArcSourceAndTarget: function (arc, xmlObject) {
-    //source and target can be inside of a port
-    var source = $(arc).attr('source');
-    var target = $(arc).attr('target');
-    var sourceNodeId, targetNodeId;
+  getPorts: function (xmlObject) {
+    return ( xmlObject._cachedPorts = xmlObject._cachedPorts || xmlObject.querySelectorAll('port'));
+  },
+  getGlyphs: function (xmlObject) {
+    var glyphs = xmlObject._cachedGlyphs;
 
-    $(xmlObject).find('glyph').each(function () {
-      if ($(this).attr('id') == source) {
-        sourceNodeId = source;
-      }
-      if ($(this).attr('id') == target) {
-        targetNodeId = target;
-      }
-    });
+    if (!glyphs) {
+      glyphs = xmlObject._cachedGlyphs = xmlObject._cachedGlyphs || xmlObject.querySelectorAll('glyph');
 
-    if (typeof sourceNodeId === 'undefined') {
-      $(xmlObject).find("port").each(function () {
-        if ($(this).attr('id') == source) {
-          sourceNodeId = $(this).parent().attr('id');
-        }
-      });
+      var id2glyph = xmlObject._id2glyph = {};
+
+      for ( var i = 0; i < glyphs.length; i++ ) {
+        var g = glyphs[i];
+        var id = g.getAttribute('id');
+
+        id2glyph[ id ] = g;
+      }
     }
 
-    if (typeof targetNodeId === 'undefined') {
-      $(xmlObject).find("port").each(function () {
-        if ($(this).attr('id') == target) {
-          targetNodeId = $(this).parent().attr('id');
+    return glyphs;
+  },
+  getGlyphById: function (xmlObject, id) {
+    this.getGlyphs(xmlObject); // make sure cache is built
+
+    return xmlObject._id2glyph[id];
+  },
+  getArcSourceAndTarget: function (arc, xmlObject) {
+    // source and target can be inside of a port
+    var source = arc.getAttribute('source');
+    var target = arc.getAttribute('target');
+    var sourceNodeId;
+    var targetNodeId;
+
+    var sourceExists = this.getGlyphById(xmlObject, source);
+    var targetExists = this.getGlyphById(xmlObject, target);
+
+    if (sourceExists) {
+      sourceNodeId = source;
+    }
+
+    if (targetExists) {
+      targetNodeId = target;
+    }
+
+
+    var i;
+    var portEls = this.getPorts(xmlObject);
+    var port;
+    if (sourceNodeId === undefined) {
+      for (i = 0; i < portEls.length; i++ ) {
+        port = portEls[i];
+        if (port.getAttribute('id') === source) {
+          sourceNodeId = port.parentElement.getAttribute('id');
         }
-      });
+      }
+    }
+
+    if (targetNodeId === undefined) {
+      for (i = 0; i < portEls.length; i++) {
+        port = portEls[i];
+        if (port.getAttribute('id') === target) {
+          targetNodeId = port.parentElement.getAttribute('id');
+        }
+      }
     }
 
     return {'source': sourceNodeId, 'target': targetNodeId};
   },
+
   getArcBendPointPositions: function (ele) {
     var bendPointPositions = [];
-    
-//    $(ele).children('start, next, end').each(function () {
-    $(ele).children('next').each(function () {
-      var posX = $(this).attr('x');
-      var posY = $(this).attr('y');
-      
-      var pos = {
+
+    var children = this.findChildNodes(ele, 'next');
+
+    for (var i = 0; i < children.length; i++) {
+      var posX = children[i].getAttribute('x');
+      var posY = children[i].getAttribute('y');
+
+      bendPointPositions.push({
         x: posX,
         y: posY
-      };
-      
-      bendPointPositions.push(pos);
-    });
-    
+      });
+    }
+
     return bendPointPositions;
   },
   addCytoscapeJsEdge: function (ele, jsonArray, xmlObject) {
-    if (!elementUtilities.handledElements[$(ele).attr('class')]) {
+    if (!elementUtilities.handledElements[ele.className]) {
       return;
     }
 
     var self = this;
     var sourceAndTarget = self.getArcSourceAndTarget(ele, xmlObject);
-    
+
     if (!this.insertedNodes[sourceAndTarget.source] || !this.insertedNodes[sourceAndTarget.target]) {
       return;
     }
-    
-    var edgeObj = new Object();
+
+    var edgeObj = {};
     var bendPointPositions = self.getArcBendPointPositions(ele);
 
-    edgeObj.id = $(ele).attr('id');
-    edgeObj.sbgnclass = $(ele).attr('class');
+    edgeObj.id = ele.getAttribute('id') || undefined;
+    edgeObj.sbgnclass = ele.className;
     edgeObj.bendPointPositions = bendPointPositions;
 
-    if ($(ele).find('glyph').length <= 0) {
+    var glyphChildren = self.findChildNodes(ele, 'glyph');
+    var glyphDescendents = ele.querySelectorAll('glyph');
+    if (glyphDescendents.length <= 0) {
       edgeObj.sbgncardinality = 0;
-    }
-    else {
-      $(ele).children('glyph').each(function () {
-        if ($(this).attr('class') == 'cardinality') {
-          edgeObj.sbgncardinality = $(this).find('label').attr('text');
+    } else {
+      for (var i = 0; i < glyphChildren.length; i++) {
+        if (glyphChildren[i].className === 'cardinality') {
+          var label = glyphChildren[i].querySelector('label');
+          edgeObj.sbgncardinality = label.getAttribute('text') || undefined;
         }
-      });
+      }
     }
 
     edgeObj.source = sourceAndTarget.source;
     edgeObj.target = sourceAndTarget.target;
 
-    edgeObj.portsource = $(ele).attr("source");
-    edgeObj.porttarget = $(ele).attr("target");
+    edgeObj.portsource = ele.getAttribute('source');
+    edgeObj.porttarget = ele.getAttribute('target');
 
     var cytoscapeJsEdge = {data: edgeObj};
     jsonArray.push(cytoscapeJsEdge);
@@ -289,15 +369,21 @@ var sbgnmlToJson = {
 
     var compartments = self.getAllCompartments(xmlObject);
 
-    $(xmlObject).find("map").children('glyph').each(function () {
-      self.traverseNodes(this, cytoscapeJsNodes, "", compartments);
-    });
+    var glyphs = self.findChildNodes(xmlObject.querySelector('map'), 'glyph');
+    var arcs = self.findChildNodes(xmlObject.querySelector('map'), 'arc');
 
-    $(xmlObject).find("map").children('arc').each(function () {
-      self.addCytoscapeJsEdge(this, cytoscapeJsEdges, xmlObject);
-    });
+    var i;
+    for (i = 0; i < glyphs.length; i++) {
+      var glyph = glyphs[i];
+      self.traverseNodes(glyph, cytoscapeJsNodes, '', compartments);
+    }
 
-    var cytoscapeJsGraph = new Object();
+    for (i = 0; i < arcs.length; i++) {
+      var arc = arcs[i];
+      self.addCytoscapeJsEdge(arc, cytoscapeJsEdges, xmlObject);
+    }
+
+    var cytoscapeJsGraph = {};
     cytoscapeJsGraph.nodes = cytoscapeJsNodes;
     cytoscapeJsGraph.edges = cytoscapeJsEdges;
 


### PR DESCRIPTION
- refactors code to get rid of various bottlenecks
- lints code
- removes jquery as a dependency


Note:  This doesnt remove the sbgn prefix from the attributes, I don't want to port over the code from sbgnml-to-cytoscape to sbgnviz and update the attributes in the same commit/pull request.


By the way, Max profiled the code and it turns out that some of the extensions used when rendering the graph in sbgnviz.update are causing about 15+ seconds of unneeded run time.  

He says that large graphs with 2000+ nodes can be loaded and rendered in about 1-2 seconds if you look into some of these changes.

You can find the doc describing them in more detail here:

https://github.com/PathwayCommons/sbgnviz-js/blob/master/sbgnslow.md
@metincansiper @ugurdogrusoz 