### PR TITLE
Statesandinfos refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /HTML5Application/nbproject/private/
 
 node_modules/
+
+src/.DS_Store
+src/utilities/.DS_Store

--- a/src/sbgn-extensions/sbgn-cy-instance.js
+++ b/src/sbgn-extensions/sbgn-cy-instance.js
@@ -61,8 +61,8 @@ var generateShapeWithPortString = function(lineHW, shapeHW, type, orientation) {
 			abovePoints = '-' + shapeHW + ' -' + shapeHW + ' ' + shapeHW + ' -' + shapeHW + ' ';
 			belowPoints = shapeHW + ' ' + shapeHW + ' -' + shapeHW + ' ' + shapeHW + ' ';
 		}
-		
-		polygonStr = "-1 -" + lineHW + " -" + shapeHW + " -" + lineHW + " ";	
+
+		polygonStr = "-1 -" + lineHW + " -" + shapeHW + " -" + lineHW + " ";
 		polygonStr += abovePoints;
 		polygonStr += shapeHW + " -" + lineHW + " 1 -" + lineHW + " 1 " + lineHW + " " + shapeHW + " " + lineHW + " ";
 		polygonStr += belowPoints;
@@ -220,14 +220,14 @@ module.exports = function () {
           var location = statesandinfos.anchorSide; // top bottom right left
           var layouts = node.data('auxunitlayouts');
           if(!layouts[location]) { // layout doesn't exist yet for this location
-            layouts[location] = new classes.AuxUnitLayout(node, location);
+            layouts[location] = classes.AuxUnitLayout.construct(node, location);
           }
           // populate the layout of this side
-          layouts[location].addAuxUnit(statesandinfos);
+          classes.AuxUnitLayout.addAuxUnit(layouts[location], statesandinfos);
         }
         // ensure that each layout has statesandinfos in correct order according to their initial positions
         for(var location in node.data('auxunitlayouts')) {
-          node.data('auxunitlayouts')[location].reorderFromPositions();
+          classes.AuxUnitLayout.reorderFromPositions(node.data('auxunitlayouts')[location]);
         }
       });
       cy.endBatch();

--- a/src/sbgn-extensions/sbgn-cy-renderer.js
+++ b/src/sbgn-extensions/sbgn-cy-renderer.js
@@ -11,6 +11,8 @@ var cyMath = math = cytoscape.math;
 var cyBaseNodeShapes = cytoscape.baseNodeShapes;
 var cyStyleProperties = cytoscape.styleProperties;
 
+var classes = require('../utilities/classes');
+
 module.exports = function () {
   var $$ = cytoscape;
   
@@ -92,14 +94,14 @@ module.exports = function () {
 
     for (var side in layouts) {
       var layout = layouts[side];
-      layout.draw(context);
+      classes.AuxUnitLayout.draw(layout, context);
     }
     context.beginPath();
     context.closePath();
   };
 
-  $$.sbgn.AfShapeFn = function (context, x, y, width, height, type) {
-    
+  $$.sbgn.UnitOfInformationShapeFn = function (context, x, y, width, height, type) {
+
     if ( type == "BA macromolecule"){
 	    cyBaseNodeShapes['roundrectangle'].draw(context, x, y, width, height);
     }
@@ -126,9 +128,9 @@ module.exports = function () {
     }
   };
 
-  $$.sbgn.AfShapeArgsFn = function (self){
-	  return [self.bbox.w, self.bbox.h, self.parent.data("class")];
-  }
+  // $$.sbgn.AfShapeArgsFn = function (self){
+	//   return [self.bbox.w, self.bbox.h, classes.getAuxUnitClass(self).getParent(self).data("class")];
+  // }
 
 
   $$.sbgn.nucleicAcidCheckPoint = function (x, y, centerX, centerY, node, threshold, points, cornerRadius) {
@@ -1535,7 +1537,7 @@ module.exports = function () {
       var state = stateAndInfos[i];
       var stateWidth = state.bbox.w;
       var stateHeight = state.bbox.h;
-      var coord = state.getAbsoluteCoord();
+      var coord = classes.StateVariable.getAbsoluteCoord(state);
       var stateCenterX = coord.x;
       var stateCenterY = coord.y;
 
@@ -1575,7 +1577,7 @@ module.exports = function () {
     if (infoBox && infoBox.isDisplayed) {
       var infoBoxWidth = infoBox.bbox.w;
       var infoBoxHeight = infoBox.bbox.h;
-      var coord = infoBox.getAbsoluteCoord();
+      var coord = classes.UnitOfInformation.getAbsoluteCoord(infoBox);
       var infoBoxCenterX = coord.x;
       var infoBoxCenterY = coord.y;
 
@@ -1621,7 +1623,7 @@ module.exports = function () {
       var state = stateAndInfos[i];
       var stateWidth = parseFloat(state.bbox.w) + threshold;
       var stateHeight = parseFloat(state.bbox.h) + threshold;
-      var coord = state.getAbsoluteCoord();
+      var coord = classes.StateVariable.getAbsoluteCoord(state);
       var stateCenterX = coord.x;
       var stateCenterY = coord.y;
 

--- a/src/utilities/classes.js
+++ b/src/utilities/classes.js
@@ -103,7 +103,8 @@ AuxiliaryUnit.drawShape = function(mainObj, context, x, y) {
 
 // draw the statesOrInfo's label at given position
 AuxiliaryUnit.drawText = function(mainObj, context, centerX, centerY) {
-  var parent = getAuxUnitClass(mainObj).getParent(mainObj);
+  var unitClass = getAuxUnitClass(mainObj);
+  var parent = unitClass.getParent(mainObj);
   var fontSize = 9; // parseInt(textProp.height / 1.5);
 
   // part of : $$.sbgn.drawText(context, textProp);
@@ -122,13 +123,13 @@ AuxiliaryUnit.drawText = function(mainObj, context, centerX, centerY) {
   if(options.fitLabelsToInfoboxes()){
     // here we memoize the truncated text into _textCache,
     // as it is not something that changes so much
-    text = mainObj.getText();
+    text = unitClass.getText(mainObj);
     var key = text + context.font + mainObj.bbox.w;
     if(mainObj._textCache && mainObj._textCache[key]) {
       text = mainObj._textCache[key];
     }
     else {
-      text = truncate(mainObj.getText(), context.font, mainObj.bbox.w);
+      text = truncate(unitClass.getText(mainObj), context.font, mainObj.bbox.w);
       if(!mainObj._textCache) {
         mainObj._textCache = {};
       }
@@ -136,7 +137,7 @@ AuxiliaryUnit.drawText = function(mainObj, context, centerX, centerY) {
     }
   }
   else {
-    text = mainObj.getText();
+    text = unitClass.getText(mainObj);
   }
 
   context.fillText(text, centerX, centerY);

--- a/src/utilities/classes.js
+++ b/src/utilities/classes.js
@@ -8,6 +8,22 @@ var truncate = require('./text-utilities').truncate;
 
 var ns = {};
 
+// Keep in mind that for each method 'mainObj' parameter refers to the main object for which the operation will be done.
+// It refers to the object that could be refered by 'this' while there was prototyping in these classes.
+// For example AuxiliaryUnit.copy(mainObj, existingInstance, newParent, newId) copies the variable passed by 'mainObj'
+// parameter and in this case 'mainObj' can be considered as `the object to be copied`
+
+// The old constructors are replaced by 'construct()' methods while removing prototyping from the classes.
+
+// 'AuxiliaryUnit' and 'AuxUnitLayout' objects keep the id of their parent nodes instead of the nodes themselves to avoid circular references.
+// To maintain this property related methods to get and set parent nodes should be used instead of directly accessing the parent object.
+
+// Also, there is a parent-child relationship between the AuxiliaryUnit class and StateVariable and UnitOfInformation
+// classes. While calling a method of AuxiliaryUnit class that method should be called from
+// the actual class of related auxilary unit (Would be StateVariable or UnitOfInformation. This is needed to prevent conflictions when the
+// methods of AuxiliaryUnit class is overriden by these classes). That class can be obtained by calling 'getAuxUnitClass(mainObj)'
+// method for the auxilary unit object.
+
 var getAuxUnitClass = function(unit) {
   // Unit parameter may pass the unit itself or the type of the unit check it
   var unitType = typeof unit === 'string' ? unit : unit.clazz;
@@ -19,10 +35,6 @@ var getAuxUnitClass = function(unit) {
 ns.getAuxUnitClass = getAuxUnitClass; // Expose getAuxUnitClass method
 
 var AuxiliaryUnit = {};
-
-// Keep in mind that for each methods mainObj parameter refers to the main object for which the operation will be done.
-// For example AuxiliaryUnit.copy(mainObj, existingInstance, newParent, newId) copies the variable passed by mainObj
-// parameter and in this case mainObj can be considered as `object to copy`
 
 // -------------- AuxiliaryUnit -------------- //
 // constructs a new auxiliary unit object and returns it

--- a/src/utilities/classes.js
+++ b/src/utilities/classes.js
@@ -197,7 +197,7 @@ AuxiliaryUnit.setAnchorSide = function(mainObj, parentBbox) {
       mainObj.anchorSide = "top";
       mainObj.bbox.y = -50;
     }
-    else if (thisY => 0) {
+    else if (thisY >= 0) {
       if (thisX > 45) {
         mainObj.anchorSide = "right";
         mainObj.bbox.x = 50;

--- a/src/utilities/classes.js
+++ b/src/utilities/classes.js
@@ -8,57 +8,99 @@ var truncate = require('./text-utilities').truncate;
 
 var ns = {};
 
+var getAuxUnitClass = function(unit) {
+  // Unit parameter may pass the unit itself or the type of the unit check it
+  var unitType = typeof unit === 'string' ? unit : unit.clazz;
+  // Retrieve and return unit class according to the unit type
+  var className = unitType === 'state variable' ? 'StateVariable' : 'UnitOfInformation';
+  return ns[className];
+};
+
+ns.getAuxUnitClass = getAuxUnitClass; // Expose getAuxUnitClass method
+
+var AuxiliaryUnit = {};
+
+// Keep in mind that for each methods mainObj parameter refers to the main object for which the operation will be done.
+// For example AuxiliaryUnit.copy(mainObj, existingInstance, newParent, newId) copies the variable passed by mainObj
+// parameter and in this case mainObj can be considered as `object to copy`
 
 // -------------- AuxiliaryUnit -------------- //
-var AuxiliaryUnit = function (parent) {
-  this.parent = parent;
-  this.id = null;
-  this.bbox = null;
-  this.coordType = "relativeToCenter";
-  this.anchorSide = null;
-  this.isDisplayed = false;
+// constructs a new auxiliary unit object and returns it
+AuxiliaryUnit.construct = function(parent) {
+  var obj = {};
+
+  if (parent) {
+    obj.parent = typeof parent === 'string' ? parent : parent.id(); // Keep parent id instead of the parent object itself to avoid circular references
+  }
+
+  obj.id = null;
+  obj.bbox = null;
+  obj.coordType = "relativeToCenter";
+  obj.anchorSide = null;
+  obj.isDisplayed = false;
+
+  return obj;
 };
+
+AuxiliaryUnit.getParent = function(mainObj) {
+  var parent = mainObj.parent;
+  // If parent variable stores the id of parent instead of the actual parent get the actual parent by id
+  if (typeof parent === 'string') {
+    return cy.getElementById(parent);
+  }
+
+  return parent;
+};
+
 AuxiliaryUnit.defaultBackgroundColor = "#ffffff";
 
 /*
  * Return a new AuxiliaryUnit object. A new parent reference and new id can
  * optionnally be passed.
  */
-AuxiliaryUnit.prototype.copy = function (existingInstance, newParent, newId) {
-  var newUnit = existingInstance ? existingInstance : new AuxiliaryUnit();
-  newUnit.parent = newParent ? newParent : this.parent;
-  newUnit.id = newId ? newId : this.id;
-  newUnit.bbox = jQuery.extend(true, {}, this.bbox);
-  newUnit.coordType = this.coordType;
-  newUnit.anchorSide = this.anchorSide;
-  newUnit.isDisplayed = this.isDisplayed;
+AuxiliaryUnit.copy = function (mainObj, existingInstance, newParent, newId) {
+  var newUnit = existingInstance ? existingInstance : AuxiliaryUnit.construct();
+
+  // Use id to avaoid circular reference
+  if (newParent && typeof newParent !== 'string') {
+    newParent = newParent.id();
+  }
+
+  newUnit.parent = newParent ? newParent : mainObj.getParent();
+  newUnit.id = newId ? newId : mainObj.id;
+  newUnit.bbox = jQuery.extend(true, {}, mainObj.bbox);
+  newUnit.coordType = mainObj.coordType;
+  newUnit.anchorSide = mainObj.anchorSide;
+  newUnit.isDisplayed = mainObj.isDisplayed;
+
   return newUnit;
 };
 
 // draw the auxiliary unit at its position
-AuxiliaryUnit.prototype.draw = function(context) {
-  var coords = this.getAbsoluteCoord();
+AuxiliaryUnit.draw = function(mainObj, context) {
+  var unitClass = getAuxUnitClass(mainObj);
+  var coords = unitClass.getAbsoluteCoord(mainObj);
 
-  this.drawShape(context, coords.x, coords.y);
-  if (this.hasText()) {
-    this.drawText(context, coords.x, coords.y);
+  unitClass.drawShape(mainObj, context, coords.x, coords.y);
+  if (unitClass.hasText(mainObj)) {
+    unitClass.drawText(mainObj, context, coords.x, coords.y);
   }
-  this.isDisplayed = true;
+  mainObj.isDisplayed = true;
 };
 
 // to be implemented by children
-AuxiliaryUnit.prototype.getText = function() {
+AuxiliaryUnit.getText = function(mainObj) {
   throw new Error("Abstract method!");
 };
-AuxiliaryUnit.prototype.hasText = function() {
+AuxiliaryUnit.hasText = function(mainObj) {
   throw new Error("Abstract method!");
 };
-AuxiliaryUnit.prototype.drawShape = function(context, x, y) {
+AuxiliaryUnit.drawShape = function(mainObj, context, x, y) {
   throw new Error("Abstract method!");
 };
 
 // draw the statesOrInfo's label at given position
-AuxiliaryUnit.prototype.drawText = function(context, centerX, centerY) {
+AuxiliaryUnit.drawText = function(mainObj, context, centerX, centerY) {
   var fontSize = 9; // parseInt(textProp.height / 1.5);
 
   // part of : $$.sbgn.drawText(context, textProp);
@@ -71,27 +113,27 @@ AuxiliaryUnit.prototype.drawText = function(context, centerX, centerY) {
   context.textAlign = "center";
   context.textBaseline = "middle";
   context.fillStyle = "#0f0f0f";
-  context.globalAlpha = this.parent.css('text-opacity') * this.parent.css('opacity'); // ?
+  context.globalAlpha = mainObj.getParent().css('text-opacity') * mainObj.getParent().css('opacity'); // ?
 
   var text;
   if(options.fitLabelsToInfoboxes()){
     // here we memoize the truncated text into _textCache,
     // as it is not something that changes so much
-    text = this.getText();
-    var key = text + context.font + this.bbox.w;
-    if(this._textCache && this._textCache[key]) {
-      text = this._textCache[key];
+    text = mainObj.getText();
+    var key = text + context.font + mainObj.bbox.w;
+    if(mainObj._textCache && mainObj._textCache[key]) {
+      text = mainObj._textCache[key];
     }
     else {
-      text = truncate(this.getText(), context.font, this.bbox.w);
-      if(!this._textCache) {
-        this._textCache = {};
+      text = truncate(mainObj.getText(), context.font, mainObj.bbox.w);
+      if(!mainObj._textCache) {
+        mainObj._textCache = {};
       }
-      this._textCache[key] = text;
+      mainObj._textCache[key] = text;
     }
   }
   else {
-    text = this.getText();
+    text = mainObj.getText();
   }
 
   context.fillText(text, centerX, centerY);
@@ -102,81 +144,82 @@ AuxiliaryUnit.prototype.drawText = function(context, centerX, centerY) {
   context.globalAlpha = oldOpacity;
 };
 
-AuxiliaryUnit.prototype.getAbsoluteCoord = function() {
-  if(this.coordType == "relativeToCenter") {
-    var absX = this.bbox.x * (this.parent.outerWidth() - this.parent._private.data['border-width']) / 100 + this.parent._private.position.x;
-    var absY = this.bbox.y * (this.parent.outerHeight() - this.parent._private.data['border-width']) / 100 + this.parent._private.position.y;
+AuxiliaryUnit.getAbsoluteCoord = function(mainObj) {
+  var parent = getAuxUnitClass(mainObj).getParent(mainObj);
+  if(mainObj.coordType == "relativeToCenter") {
+    var absX = mainObj.bbox.x * (parent.outerWidth() - parent._private.data['border-width']) / 100 + parent._private.position.x;
+    var absY = mainObj.bbox.y * (parent.outerHeight() - parent._private.data['border-width']) / 100 + parent._private.position.y;
     return {x: absX, y: absY};
   }
-  else if(this.coordType == "relativeToSide") {
-    if (this.anchorSide == "top" || this.anchorSide == "bottom") {
-      var absX = this.parent._private.position.x - (this.parent.outerWidth() - this.parent._private.data['border-width']) / 2 + this.bbox.x;
-      var absY = this.bbox.y * (this.parent.outerHeight() - this.parent._private.data['border-width']) / 100 + this.parent._private.position.y;
+  else if(mainObj.coordType == "relativeToSide") {
+    if (mainObj.anchorSide == "top" || mainObj.anchorSide == "bottom") {
+      var absX = parent._private.position.x - (parent.outerWidth() - parent._private.data['border-width']) / 2 + mainObj.bbox.x;
+      var absY = mainObj.bbox.y * (parent.outerHeight() - parent._private.data['border-width']) / 100 + parent._private.position.y;
     }
     else {
-      var absY = this.parent._private.position.y - (this.parent.outerHeight() - this.parent._private.data['border-width']) / 2 + this.bbox.y;
-      var absX = this.bbox.x * (this.parent.outerWidth() - this.parent._private.data['border-width']) / 100 + this.parent._private.position.x;
+      var absY = parent._private.position.y - (parent.outerHeight() - parent._private.data['border-width']) / 2 + mainObj.bbox.y;
+      var absX = mainObj.bbox.x * (parent.outerWidth() - parent._private.data['border-width']) / 100 + parent._private.position.x;
     }
 
   // due to corner of barrel shaped compartment shift absX to right
-  if (this.parent.data("class") == "compartment"){
-      absX += this.parent.outerWidth() * 0.1;
+  if (parent.data("class") == "compartment"){
+      absX += parent.outerWidth() * 0.1;
   };
     return {x: absX, y: absY};
   }
 };
 
-AuxiliaryUnit.prototype.setAnchorSide = function(parentBbox) {
-  if(this.coordType == "relativeToCenter") {
-    var thisX = this.bbox.x;
-    var thisY = this.bbox.y;
+AuxiliaryUnit.setAnchorSide = function(mainObj, parentBbox) {
+  if(mainObj.coordType == "relativeToCenter") {
+    var thisX = mainObj.bbox.x;
+    var thisY = mainObj.bbox.y;
     if(thisY > 45) {
-      this.anchorSide = "bottom";
-      this.bbox.y = 50;
+      mainObj.anchorSide = "bottom";
+      mainObj.bbox.y = 50;
     }
     else if (thisY < -45) {
-      this.anchorSide = "top";
-      this.bbox.y = -50;
+      mainObj.anchorSide = "top";
+      mainObj.bbox.y = -50;
     }
     else if (thisY => 0) {
       if (thisX > 45) {
-        this.anchorSide = "right";
-        this.bbox.x = 50;
+        mainObj.anchorSide = "right";
+        mainObj.bbox.x = 50;
       }
       else if (thisX < -45) {
-        this.anchorSide = "left";
-        this.bbox.x = -50;
+        mainObj.anchorSide = "left";
+        mainObj.bbox.x = -50;
       }
       else {
-        this.anchorSide = "bottom";
-        this.bbox.y = 50;
+        mainObj.anchorSide = "bottom";
+        mainObj.bbox.y = 50;
       }
     }
     else {
       if (thisX > 45) {
-        this.anchorSide = "right";
-        this.bbox.x = 50;
+        mainObj.anchorSide = "right";
+        mainObj.bbox.x = 50;
       }
       else if (thisX < -45) {
-        this.anchorSide = "left";
-        this.bbox.x = -50;
+        mainObj.anchorSide = "left";
+        mainObj.bbox.x = -50;
       }
       else {
-        this.anchorSide = "top";
-        this.bbox.y = -50;
+        mainObj.anchorSide = "top";
+        mainObj.bbox.y = -50;
       }
     }
   }
 };
 
-AuxiliaryUnit.prototype.addToParent = function (parentNode, location, position, index) {
+AuxiliaryUnit.addToParent = function (mainObj, parentNode, location, position, index) {
 
   // add state var to the parent's statesandinfos
   if(typeof index != "undefined") { // specific index provided (for undo/redo consistency)
-    parentNode.data('statesandinfos').splice(index, 0, this);
+    parentNode.data('statesandinfos').splice(index, 0, mainObj);
   }
   else {
-    parentNode.data('statesandinfos').push(this);
+    parentNode.data('statesandinfos').push(mainObj);
   }
 
   if(!parentNode.data('auxunitlayouts')) { // ensure minimal initialization
@@ -188,34 +231,35 @@ AuxiliaryUnit.prototype.addToParent = function (parentNode, location, position, 
   // here we are sure to have a location even if it was not provided as argument
   // get or create the necessary layout
   if(!parentNode.data('auxunitlayouts')[location]) {
-    parentNode.data('auxunitlayouts')[location] = new ns.AuxUnitLayout(parentNode, location);
+    parentNode.data('auxunitlayouts')[location] = AuxUnitLayout.construct(parentNode, location);
   }
   var layout = parentNode.data('auxunitlayouts')[location];
-  this.anchorSide = location;
+  mainObj.anchorSide = location;
   switch(location) {
-    case "top": this.bbox.y = -50; break;
-    case "bottom": this.bbox.y = 50; break;
-    case "left": this.bbox.x = -50; break;
-    case "right": this.bbox.x = -50; break;
+    case "top": mainObj.bbox.y = -50; break;
+    case "bottom": mainObj.bbox.y = 50; break;
+    case "left": mainObj.bbox.x = -50; break;
+    case "right": mainObj.bbox.x = -50; break;
   }
   // add stateVar to layout, precomputing of relative coords will be triggered accordingly
-  var insertedPosition = layout.addAuxUnit(this, position);
+  var insertedPosition = AuxUnitLayout.addAuxUnit(layout, mainObj, position);
   return insertedPosition;
 }
 
-AuxiliaryUnit.prototype.removeFromParent = function () {
-  var parentLayout = this.parent.data('auxunitlayouts')[this.anchorSide];
-  parentLayout.removeAuxUnit(this);
-  if (parentLayout.isEmpty()){
-    delete this.parent.data('auxunitlayouts')[this.anchorSide];
+AuxiliaryUnit.removeFromParent = function (mainObj) {
+  var parent = getAuxUnitClass(mainObj).getParent(mainObj);
+  var parentLayout = parent.data('auxunitlayouts')[mainObj.anchorSide];
+  AuxUnitLayout.removeAuxUnit(parentLayout, mainObj);
+  if (AuxUnitLayout.isEmpty(parentLayout)){
+    delete parent.data('auxunitlayouts')[mainObj.anchorSide];
   }
-  var statesandinfos = this.parent.data('statesandinfos');
-  var index  = statesandinfos.indexOf(this);
+  var statesandinfos = parent.data('statesandinfos');
+  var index  = statesandinfos.indexOf(mainObj);
   statesandinfos.splice(index, 1);
 };
 
-AuxiliaryUnit.prototype.getPositionIndex = function() {
-  return this.parent.data('auxunitlayouts')[this.anchorSide].units.indexOf(this);
+AuxiliaryUnit.getPositionIndex = function(mainObj) {
+  return getAuxUnitClass(mainObj).getParent(mainObj).data('auxunitlayouts')[mainObj.anchorSide].units.indexOf(mainObj);
 };
 
 ns.AuxiliaryUnit = AuxiliaryUnit;
@@ -225,36 +269,46 @@ ns.AuxiliaryUnit = AuxiliaryUnit;
 /**
  * parent has to be a stateful EPN (complex, macromolecule or nucleic acid)
  */
-var StateVariable = function (value, stateVariableDefinition, parent) {
-  AuxiliaryUnit.call(this, parent);
-  this.state = {};
-  this.state.value = value;
-  this.state.variable = null;
-  this.stateVariableDefinition = stateVariableDefinition;
-  this.clazz = "state variable";
+
+var StateVariable = {};
+
+// StateVariable extends AuxiliaryUnit by inheriting each static property of it
+for (var prop in AuxiliaryUnit) {
+  StateVariable[prop] = AuxiliaryUnit[prop];
+}
+
+// Construct a state variable object by extending default behaviours of a AuxiliaryUnit object and returns that object
+StateVariable.construct = function(value, stateVariableDefinition, parent) {
+  var obj = AuxiliaryUnit.construct(parent);
+  obj.state = {};
+  obj.state.value = value;
+  obj.state.variable = null;
+  obj.stateVariableDefinition = stateVariableDefinition;
+  obj.clazz = "state variable";
+
+  return obj;
 };
-StateVariable.prototype = Object.create(AuxiliaryUnit.prototype);
-StateVariable.prototype.constructor = StateVariable;
+
 StateVariable.shapeRadius = 15;
 
-StateVariable.prototype.getText = function() {
-  var stateValue = this.state.value || '';
-  var stateVariable = this.state.variable ? "@" + this.state.variable : "";
+StateVariable.getText = function(mainObj) {
+  var stateValue = mainObj.state.value || '';
+  var stateVariable = mainObj.state.variable ? "@" + mainObj.state.variable : "";
 
   return stateValue + stateVariable;
 };
 
-StateVariable.prototype.hasText = function() {
-  return (this.state.value && this.state.value != "") || (this.state.variable && this.state.variable != "");
+StateVariable.hasText = function(mainObj) {
+  return (mainObj.state.value && mainObj.state.value != "") || (mainObj.state.variable && mainObj.state.variable != "");
 };
 
-StateVariable.prototype.drawShape = function(context, x, y) {
+StateVariable.drawShape = function(mainObj, context, x, y) {
   cytoscape.sbgn.drawRoundRectanglePath(context,
               x, y,
-              this.bbox.w, this.bbox.h,
-              Math.min(this.bbox.w / 2, this.bbox.h / 2, StateVariable.shapeRadius));
+              mainObj.bbox.w, mainObj.bbox.h,
+              Math.min(mainObj.bbox.w / 2, mainObj.bbox.h / 2, StateVariable.shapeRadius));
   var tmp_ctxt = context.fillStyle;
-  context.fillStyle = AuxiliaryUnit.defaultBackgroundColor;
+  context.fillStyle = StateVariable.defaultBackgroundColor;
   context.fill();
   context.fillStyle = tmp_ctxt;
   context.stroke();
@@ -262,49 +316,53 @@ StateVariable.prototype.drawShape = function(context, x, y) {
 
 StateVariable.create = function(parentNode, value, variable, bbox, location, position, index) {
   // create the new state var of info
-  var stateVar = new ns.StateVariable();
-  stateVar.parent = parentNode;
+  var stateVar = StateVariable.construct();
+  if (parentNode) {
+    // Use id of parent node instead of the node itself to avaoid circular references
+    stateVar.parent = typeof parentNode === 'string' ? parentNode : parentNode.id();
+  }
+
   stateVar.value = value;
   stateVar.variable = variable;
   stateVar.state = {value: value, variable: variable};
   stateVar.bbox = bbox;
 
   // link to layout
-  position = stateVar.addToParent(parentNode, location, position, index);
+  position = StateVariable.addToParent(stateVar, parentNode, location, position, index);
 
   return {
-    index: stateVar.parent.data('statesandinfos').indexOf(stateVar),
+    index: StateVariable.getParent(stateVar).data('statesandinfos').indexOf(stateVar),
     location: stateVar.anchorSide,
     position: position
   }
 };
 
-StateVariable.prototype.remove = function () {
-  var position = this.getPositionIndex();
-  var index = this.parent.data('statesandinfos').indexOf(this);
-  this.removeFromParent();
+StateVariable.remove = function (mainObj) {
+  var position = StateVariable.getPositionIndex(mainObj);
+  var index = StateVariable.getParent(mainObj).data('statesandinfos').indexOf(mainObj);
+  StateVariable.removeFromParent(mainObj);
   //console.log("after remove", this.parent.data('auxunitlayouts'), this.parent.data('statesandinfos'));
   return {
     clazz: "state variable",
     state: {
-      value: this.state.value,
-      variable: this.state.variable
+      value: mainObj.state.value,
+      variable: mainObj.state.variable
     },
     bbox: {
-      w: this.bbox.w,
-      h: this.bbox.h
+      w: mainObj.bbox.w,
+      h: mainObj.bbox.h
     },
-    location: this.anchorSide,
+    location: mainObj.anchorSide,
     position: position,
     index: index
   };
 };
 
-StateVariable.prototype.copy = function(newParent, newId) {
-  var newStateVar = AuxiliaryUnit.prototype.copy.call(this, new StateVariable(), newParent, newId);
-  newStateVar.state = jQuery.extend(true, {}, this.state);
-  newStateVar.stateVariableDefinition = this.stateVariableDefinition;
-  newStateVar.clazz = this.clazz;
+StateVariable.copy = function(mainObj, newParent, newId) {
+  var newStateVar = AuxiliaryUnit.copy(mainObj, StateVariable.construct(), newParent, newId);
+  newStateVar.state = jQuery.extend(true, {}, mainObj.state);
+  newStateVar.stateVariableDefinition = mainObj.stateVariableDefinition;
+  newStateVar.clazz = mainObj.clazz;
   return newStateVar;
 };
 
@@ -314,50 +372,39 @@ ns.StateVariable = StateVariable;
 // -------------- UnitOfInformation -------------- //
 /**
  * parent can be an EPN, compartment or subunit
- * The shape can vary and can be provided to the constructor. By default, it will be rendered with the shape 
- * of PD units of information.
- * To provide a custom shape, 2 functions must be passed:
- *  - shapeFn: the shape function itself, the function that will be called to render the shape
- *             The prototype should be: fn(context, x, y, [some other arguments])
- *  - shapeArgsFn: prototype function(self), it should return an array of arguments that will be passed to shapeFn
- *                 See example as the default below.
- *  To render the shape, we will simply do: shapeFn.apply(null, [context, x, y] + rest of the list provided by shapeArgsFn() )
  */
-var UnitOfInformation = function (value, parent, shapeFn, shapeArgsFn) {
-  AuxiliaryUnit.call(this, parent);
-  this.label = {text: value}; // from legacy code, contains {text: }
-  this.clazz = "unit of information";
-  if(shapeFn && shapeArgsFn) {
-    this.shapeFn = shapeFn;
-    this.shapeArgsFn = shapeArgsFn;
-  }
-  else { // default shape is rectangle
-    this.shapeFn = function(c,x,y,w,h){
-      cytoscape.baseNodeShapes['rectangle'].draw(c, x, y, w, h)
-    };
 
-    this.shapeArgsFn = function (self) {
-      return [self.bbox.w, self.bbox.h, 0];
-    };
-  }
+var UnitOfInformation = {};
+
+// UnitOfInformation extends AuxiliaryUnit by inheriting each static property of it
+for (var prop in AuxiliaryUnit) {
+  UnitOfInformation[prop] = AuxiliaryUnit[prop];
+}
+
+// Constructs a UnitOfInformation object by extending properties of an AuxiliaryUnit object and return that object
+UnitOfInformation.construct = function(value, parent) {
+  var obj = AuxiliaryUnit.construct(parent);
+  obj.label = {text: value}; // from legacy code, contains {text: }
+  obj.clazz = "unit of information";
+
+  return obj;
 };
-UnitOfInformation.prototype = Object.create(AuxiliaryUnit.prototype);
-UnitOfInformation.prototype.constructor = UnitOfInformation;
+
 UnitOfInformation.shapeRadius = 4;
 
-UnitOfInformation.prototype.getText = function() {
-  return this.label.text;
+UnitOfInformation.getText = function(mainObj) {
+  return mainObj.label.text;
 };
 
-UnitOfInformation.prototype.hasText = function() {
-  return this.label.text && this.label.text != "";
+UnitOfInformation.hasText = function(mainObj) {
+  return mainObj.label.text && mainObj.label.text != "";
 };
 
-UnitOfInformation.prototype.drawShape = function(context, x, y) {
-  var args = [context, x, y].concat(this.shapeArgsFn(this));
-  this.shapeFn.apply(null, args);
+UnitOfInformation.drawShape = function(mainObj, context, x, y) {
+  cytoscape.sbgn.UnitOfInformationShapeFn(context, x, y, mainObj.bbox.w, mainObj.bbox.h,
+                  getAuxUnitClass(mainObj).getParent(mainObj).data("class"));
   var tmp_ctxt = context.fillStyle;
-  context.fillStyle = AuxiliaryUnit.defaultBackgroundColor;
+  context.fillStyle = UnitOfInformation.defaultBackgroundColor;
   context.fill();
   context.fillStyle = tmp_ctxt;
   context.stroke();
@@ -371,47 +418,45 @@ UnitOfInformation.prototype.drawShape = function(context, x, y) {
  * @param [position] - its position in the order of elements placed on the same location
  * @param [index] - its index in the statesandinfos list
  */
-UnitOfInformation.create = function (parentNode, value, bbox, location, position, index, shapeFn, shapeArgsFn) {
+UnitOfInformation.create = function (parentNode, value, bbox, location, position, index) {
   // create the new unit of info
-  var unit = new ns.UnitOfInformation(value, parentNode, shapeFn, shapeArgsFn);
+  var unit = UnitOfInformation.construct(value, parentNode);
   unit.bbox = bbox;
 
   //console.log("will insert on", location, position);
-  position = unit.addToParent(parentNode, location, position, index);
+  position = UnitOfInformation.addToParent(unit, parentNode, location, position, index);
 
   return {
-    index: unit.parent.data('statesandinfos').indexOf(unit),
+    index: UnitOfInformation.getParent(unit).data('statesandinfos').indexOf(unit),
     location: unit.anchorSide,
     position: position
   }
 };
 
-UnitOfInformation.prototype.remove = function () {
-  var position = this.getPositionIndex();
-  var index = this.parent.data('statesandinfos').indexOf(this);
-  this.removeFromParent();
+UnitOfInformation.remove = function (mainObj) {
+  var position = UnitOfInformation.getPositionIndex(mainObj);
+  var index = UnitOfInformation.getParent(mainObj).data('statesandinfos').indexOf(mainObj);
+  UnitOfInformation.removeFromParent(mainObj);
   //console.log("after remove", this.parent.data('auxunitlayouts'), this.parent.data('statesandinfos'));
   return {
     clazz: "unit of information",
     label: {
-      text: this.label.text
+      text: mainObj.label.text
     },
     bbox: {
-      w: this.bbox.w,
-      h: this.bbox.h
+      w: mainObj.bbox.w,
+      h: mainObj.bbox.h
     },
-    location: this.anchorSide,
+    location: mainObj.anchorSide,
     position: position,
     index: index
   };
 };
 
-UnitOfInformation.prototype.copy = function(newParent, newId) {
-  var newUnitOfInfo = AuxiliaryUnit.prototype.copy.call(this, new UnitOfInformation(), newParent, newId);
-  newUnitOfInfo.label = jQuery.extend(true, {}, this.label);
-  newUnitOfInfo.clazz = this.clazz;
-  newUnitOfInfo.shapeFn = this.shapeFn;
-  newUnitOfInfo.shapeArgsFn = this.shapeArgsFn;
+UnitOfInformation.copy = function(mainObj, newParent, newId) {
+  var newUnitOfInfo = AuxiliaryUnit.copy(mainObj, UnitOfInformation.construct(), newParent, newId);
+  newUnitOfInfo.label = jQuery.extend(true, {}, mainObj.label);
+  newUnitOfInfo.clazz = mainObj.clazz;
   return newUnitOfInfo;
 };
 
@@ -423,39 +468,45 @@ ns.UnitOfInformation = UnitOfInformation;
  * The type of the EPN, for example there can be severals myosin EPN, but only one myosin EntityType
  * This class will hold the information regarding state variable, that are shared between all myosins
  */
-var EntityType = function (name, EPN) {
-  this.name = name; // normally the same as its EPNs
-  this.stateVariableDefinitions = []; // 0 or many shared state definitions
-  this.EPNs = []; // there should always be at least 1 element, else no reason to exist
+
+var EntityType = {};
+
+// Constructs an EntityType object and returns it
+EntityType.construct = function(name, EPN) {
+  var obj = {};
+  obj.name = name; // normally the same as its EPNs
+  obj.stateVariableDefinitions = []; // 0 or many shared state definitions
+  obj.EPNs = []; // there should always be at least 1 element, else no reason to exist
+  return obj;
 };
 
-EntityType.prototype.createNewDefinitionFor = function (stateVar) {
-  var newDefinition = new ns.StateVariableDefinition();
-  newDefinition.entityType = this;
+EntityType.createNewDefinitionFor = function (mainObj, stateVar) {
+  var newDefinition = StateVariableDefinition.construct();
+  newDefinition.entityType = mainObj;
   newDefinition.stateVariables.push(stateVar);
 
   stateVar.stateVariableDefinition = newDefinition;
-  stateVar.parent.data('entityType', this);
-  this.stateVariableDefinitions.push(newDefinition);
+  stateVar.parent.data('entityType', mainObj);
+  mainObj.stateVariableDefinitions.push(newDefinition);
 };
 
-EntityType.prototype.assignStateVariable = function (stateVar) {
+EntityType.assignStateVariable = function (mainObj, stateVar) {
   // first trivial case, no stateDefinition yet for this entityType, so this is a new one
-  if (this.stateVariableDefinitions.length == 0) {
-    this.createNewDefinitionFor(stateVar);
+  if (mainObj.stateVariableDefinitions.length == 0) {
+    EntityType.createNewDefinitionFor(mainObj, stateVar);
   }
   else { // if definitions are already present, we need to match those to the current stateVariable
-    for(var i=0; i < this.stateVariableDefinitions.length; i++) {
-      var matchStateDef = this.stateVariableDefinitions[i];
-      if (matchStateDef.matchStateVariable(stateVar)){
+    for(var i=0; i < mainObj.stateVariableDefinitions.length; i++) {
+      var matchStateDef = mainObj.stateVariableDefinitions[i];
+      if (StateVariableDefinition.matchStateVariable(matchStateDef, stateVar)){
         matchStateDef.stateVariables.push(stateVar);
         stateVar.stateVariableDefinition = matchStateDef;
-        stateVar.parent.data('entityType', this);
+        stateVar.parent.data('entityType', mainObj);
         return;
       }
     }
     // if nothing was matched among the current stateVarDef of this entityType, create new one
-    this.createNewDefinitionFor(stateVar);
+    EntityType.createNewDefinitionFor(mainObj, stateVar);
   }
 };
 
@@ -467,28 +518,34 @@ ns.EntityType = EntityType;
  * The state variable definition is something shared across different EPNs
  * The concerned EPNs are linked through the entitype reference
  */
-var StateVariableDefinition = function (name, entityType) {
-  this.name = name;
-  this.entityType = entityType; // reference to owning entity type
-  this.stateVariables = []; // there should always be at least 1 element, else no reason to exist
+
+var StateVariableDefinition = {};
+
+// Constructs a new StateVariableDefinition object and returns it
+StateVariableDefinition.construct = function(name, entityType) {
+  var obj = {};
+  obj.name = name;
+  obj.entityType = entityType; // reference to owning entity type
+  obj.stateVariables = []; // there should always be at least 1 element, else no reason to exist
+  return obj;
 };
 
 /**
  * returns an array of elements that share this state definition
  */
-StateVariableDefinition.prototype.getConcernedEPNs = function() {
-  return this.entityType.EPNs;
+StateVariableDefinition.getConcernedEPNs = function(mainObj) {
+  return mainObj.entityType.EPNs;
 };
 
 /**
  * Guess if the provided stateVariable belongs to this stateVarDefinition
- * We consider it does, if either the statevar.value or statevar.variable are matching one 
+ * We consider it does, if either the statevar.value or statevar.variable are matching one
  * if the statevar in the set of the StateVarDef
  * This is because we normally compare only stateVariables from the same entityType
  */
-StateVariableDefinition.prototype.matchStateVariable = function(stateVar) {
-  for(var i=0; i < this.stateVariables.length; i++) {
-    var matchStateVar = this.stateVariables[i];
+StateVariableDefinition.matchStateVariable = function(mainObj, stateVar) {
+  for(var i=0; i < mainObj.stateVariables.length; i++) {
+    var matchStateVar = mainObj.stateVariables[i];
     // Don't match a stateVar against another one from the same element.
     // If 2 statevar on the same element, then they have to belong to 2 different stateVarDefinitions
     if(matchStateVar.parent === stateVar.parent) {
@@ -518,19 +575,40 @@ ns.StateVariableDefinition = StateVariableDefinition;
 /**
  * Responsible for laying out the auxiliary units contained on a same edge
  */
-var AuxUnitLayout = function (parentNode, location, alignment) {
-  this.units = [];
-  this.location = location;
-  this.alignment = alignment || "left"; // this was intended to be used, but it isn't for now
-  this.parentNode = parentNode;
-  this.renderLengthCache = [];
-  this.lengthUsed = 0;
+
+var AuxUnitLayout = {};
+
+AuxUnitLayout.construct = function(parentNode, location, alignment) {
+  var obj = {};
+  obj.units = [];
+  obj.location = location;
+  obj.alignment = alignment || "left"; // this was intended to be used, but it isn't for now
+  if (parentNode) {
+      obj.parentNode = typeof parentNode === 'string' ? parentNode : parentNode.id(); // Keep id of parent node to avaoid circular references
+  }
+
+  obj.renderLengthCache = [];
+  obj.lengthUsed = 0;
 
   // specific rules for the layout
   if(parentNode.data('class') == "simple chemical") {
-    this.outerMargin = 3;
+    obj.outerMargin = 3;
   }
+
+  return obj;
 };
+
+AuxUnitLayout.getParentNode = function(mainObj) {
+  var parentNode = mainObj.parentNode;
+
+  // If parentNode is id of parent node rather than being itself get the parent node by that id
+  if (typeof parentNode === 'string') {
+    return cy.getElementById(parentNode)
+  }
+
+  return parentNode;
+};
+
 /**
  * outerMargin: the left and right space left between the side of the node, and the first (and last) box
  * unitGap: the space between the auxiliary units
@@ -538,7 +616,7 @@ var AuxUnitLayout = function (parentNode, location, alignment) {
  * forcing a minimum size for the node
  * maxUnitDisplayed: show at most this amount of units, even when there is enough space
  *
- * These options can be defined at the instance level. If it is found in an instance, then it 
+ * These options can be defined at the instance level. If it is found in an instance, then it
  * takes precedence. If not found, the following class' values are used.
  */
 AuxUnitLayout.outerMargin = 10;
@@ -546,40 +624,40 @@ AuxUnitLayout.unitGap = 5;
 AuxUnitLayout.alwaysShowAuxUnits = false;
 AuxUnitLayout.maxUnitDisplayed = -1;
 
-AuxUnitLayout.prototype.update = function(doForceUpdate) {
-  this.precomputeCoords(doForceUpdate);
+AuxUnitLayout.update = function(mainObj, doForceUpdate) {
+  AuxUnitLayout.precomputeCoords(mainObj, doForceUpdate);
 };
 
-AuxUnitLayout.prototype.addAuxUnit = function(unit, position) {
+AuxUnitLayout.addAuxUnit = function(mainObj, unit, position) {
   if(typeof position != "undefined") {
     //console.log("add unit at positiion", position);
-    this.units.splice(position, 0, unit);
+    mainObj.units.splice(position, 0, unit);
   }
   else {
-    this.units.push(unit);
-    position = this.units.length - 1;
+    mainObj.units.push(unit);
+    position = mainObj.units.length - 1;
   }
 
-  this.updateLengthCache();
-  this.update(true);
-  if (this.getAlwaysShowAuxUnits()) {
+  AuxUnitLayout.updateLengthCache(mainObj);
+  AuxUnitLayout.update(mainObj, true);
+  if (AuxUnitLayout.getAlwaysShowAuxUnits(mainObj)) {
     // set a minimum size according to both sides on the same orientation
-    this.setParentMinLength();
+    AuxUnitLayout.setParentMinLength(mainObj);
     // need to resize the parent in case the space was too small
-    this.resizeParent(this.lengthUsed);
+    AuxUnitLayout.resizeParent(mainObj, mainObj.lengthUsed);
   }
   //cy.style().update(); // <- was it really necessary ?
   return position;
 };
 
-AuxUnitLayout.prototype.removeAuxUnit = function(unit) {
-  var index = this.units.indexOf(unit);
-  this.units.splice(index, 1);
-  this.updateLengthCache();
-  this.update(true);
-  if (this.getAlwaysShowAuxUnits()) {
+AuxUnitLayout.removeAuxUnit = function(mainObj, unit) {
+  var index = mainObj.units.indexOf(unit);
+  mainObj.units.splice(index, 1);
+  AuxUnitLayout.updateLengthCache(mainObj);
+  AuxUnitLayout.update(mainObj, true);
+  if (AuxUnitLayout.getAlwaysShowAuxUnits(mainObj)) {
     // set a minimum size according to both sides on the same orientation
-    this.setParentMinLength();
+    AuxUnitLayout.setParentMinLength(mainObj);
   }
   cy.style().update();
 };
@@ -588,10 +666,9 @@ AuxUnitLayout.prototype.removeAuxUnit = function(unit) {
  * reorder boxes using their defined positions. From left to right and top to bottom.
  * this ensures that their order in the layout's list corresponds to the reality of the map.
  */
-AuxUnitLayout.prototype.reorderFromPositions = function() {
-  var self = this;
-  this.units.sort(function(a, b) {
-    if(self.location == "top" || self.location == "bottom") {
+AuxUnitLayout.reorderFromPositions = function(mainObj) {
+  mainObj.units.sort(function(a, b) {
+    if(mainObj.location == "top" || mainObj.location == "bottom") {
       if (a.bbox.x < b.bbox.x) {
         return -1;
       }
@@ -610,8 +687,8 @@ AuxUnitLayout.prototype.reorderFromPositions = function() {
     return 0;
   });
   //console.log("units after reoarder", this.units);
-  this.updateLengthCache();
-  this.update(true);
+  AuxUnitLayout.updateLengthCache(mainObj);
+  AuxUnitLayout.update(mainObj, true);
 };
 
 /**
@@ -619,19 +696,19 @@ AuxUnitLayout.prototype.reorderFromPositions = function() {
  * can then be compared against the parent node's dimensions, to decide how many
  * aux units to draw.
  */
-AuxUnitLayout.prototype.updateLengthCache = function() {
-  this.renderLengthCache = [0];
-  var previous = this.getOuterMargin();
-  for(var i=0; i < this.units.length; i++) {
+AuxUnitLayout.updateLengthCache = function(mainObj) {
+  mainObj.renderLengthCache = [0];
+  var previous = AuxUnitLayout.getOuterMargin(mainObj);
+  for(var i=0; i < mainObj.units.length; i++) {
     var currentLength;
-    if(this.isTorB()) {
-      currentLength = this.units[i].bbox.w;
+    if(AuxUnitLayout.isTorB(mainObj)) {
+      currentLength = mainObj.units[i].bbox.w;
     }
     else {
-      currentLength = this.units[i].bbox.h;
+      currentLength = mainObj.units[i].bbox.h;
     }
-    this.renderLengthCache.push(previous + currentLength + this.getOuterMargin());
-    previous += currentLength + this.getUnitGap();
+    mainObj.renderLengthCache.push(previous + currentLength + AuxUnitLayout.getOuterMargin(mainObj));
+    previous += currentLength + AuxUnitLayout.getUnitGap(mainObj);
   }
 };
 
@@ -641,71 +718,71 @@ AuxUnitLayout.prototype.updateLengthCache = function() {
  * The number returned says: we are able to draw the N first units of the lists.
  * Unused for now.
  */
-AuxUnitLayout.prototype.getDrawableUnitAmount = function() {
-  if(this.getAlwaysShowAuxUnits()) {
+AuxUnitLayout.getDrawableUnitAmount = function(mainObj) {
+  if(AuxUnitLayout.getAlwaysShowAuxUnits(mainObj)) {
     // bypass all this
-    return this.units.length;
+    return mainObj.units.length;
   }
 
   // get the length of the side on which we draw
   var availableSpace;
-  if (this.isTorB()) {
-    availableSpace = this.parentNode.outerWidth();
+  if (AuxUnitLayout.isTorB(mainObj)) {
+    availableSpace = AuxUnitLayout.getParentNode(mainObj).outerWidth();
   }
   else {
-    availableSpace = this.parentNode.outerHeight();
+    availableSpace = AuxUnitLayout.getParentNode(mainObj).outerHeight();
   }
   // loop over the cached precomputed lengths
-  for(var i=0; i < this.renderLengthCache.length; i++) {
-    if(this.renderLengthCache[i] > availableSpace) {
+  for(var i=0; i < mainObj.renderLengthCache.length; i++) {
+    if(mainObj.renderLengthCache[i] > availableSpace) {
       // stop if we overflow
       return i - 1;
     }
   }
-  return this.units.length;
+  return mainObj.units.length;
 };
 
-AuxUnitLayout.prototype.setDisplayedUnits = function () {
+AuxUnitLayout.setDisplayedUnits = function (mainObj) {
   // get the length of the side on which we draw
   var availableSpace;
-  if (this.isTorB()) {
-    availableSpace = this.parentNode.outerWidth();
+  if (AuxUnitLayout.isTorB(mainObj)) {
+    availableSpace = AuxUnitLayout.getParentNode(mainObj).outerWidth();
     // due to corner of barrel shaped compartment decrease availableSpace -- no infobox on corners
-    if (this.parentNode.data("class") == "compartment")
+    if (AuxUnitLayout.getParentNode(mainObj).data("class") == "compartment")
         availableSpace *= 0.8;
   }
   else {
-    availableSpace = this.parentNode.outerHeight();
+    availableSpace = AuxUnitLayout.getParentNode(mainObj).outerHeight();
   }
 
   // there is always n+1 elements in the cachedLength for n units
-  var alwaysShowAuxUnits = this.getAlwaysShowAuxUnits();
-  var maxUnitDisplayed = this.getMaxUnitDisplayed();
-  for(var i=0; i < this.units.length; i++) {
-    if((this.renderLengthCache[i+1] <= availableSpace // do we have enough space?
+  var alwaysShowAuxUnits = AuxUnitLayout.getAlwaysShowAuxUnits(mainObj);
+  var maxUnitDisplayed = AuxUnitLayout.getMaxUnitDisplayed(mainObj);
+  for(var i=0; i < mainObj.units.length; i++) {
+    if((mainObj.renderLengthCache[i+1] <= availableSpace // do we have enough space?
       && (maxUnitDisplayed == -1 || i < maxUnitDisplayed)) // is there no limit? or are we under that limit?
       || alwaysShowAuxUnits) { // do we always want to show everything regardless?
-      this.units[i].isDisplayed = true;
+      mainObj.units[i].isDisplayed = true;
     }
     else {
-      this.units[i].isDisplayed = false;
+      mainObj.units[i].isDisplayed = false;
     }
   }
 };
 
 // TODO find a way to refactor, remove ugliness of top-bottom/left-right.
-AuxUnitLayout.prototype.precomputeCoords = function (doForceUpdate) {
-  this.setDisplayedUnits();
+AuxUnitLayout.precomputeCoords = function (mainObj, doForceUpdate) {
+  AuxUnitLayout.setDisplayedUnits(mainObj);
 
-  var lengthUsed = this.getOuterMargin();
+  var lengthUsed = AuxUnitLayout.getOuterMargin(mainObj);
   var finalLengthUsed = lengthUsed;
-  var unitGap = this.getUnitGap();
-  for(var i=0; i < this.units.length; i++) {
+  var unitGap = AuxUnitLayout.getUnitGap(mainObj);
+  for(var i=0; i < mainObj.units.length; i++) {
     // change the coordinate system of the auxiliary unit according to the chosen layout
-    var auxUnit = this.units[i];
+    var auxUnit = mainObj.units[i];
     if (auxUnit.coordType != "relativeToSide" || doForceUpdate) {
       if (auxUnit.coordType == "relativeToCenter" || doForceUpdate) {
-        if(this.isTorB()) {
+        if(AuxUnitLayout.isTorB(mainObj)) {
           //auxUnit.bbox.y = 0;
           auxUnit.bbox.x = lengthUsed + auxUnit.bbox.w / 2;
         }
@@ -714,10 +791,10 @@ AuxUnitLayout.prototype.precomputeCoords = function (doForceUpdate) {
           auxUnit.bbox.y = lengthUsed + auxUnit.bbox.h / 2;
         }
       }
-      auxUnit.coordType = "relativeToSide"; 
+      auxUnit.coordType = "relativeToSide";
     }
 
-    if(this.isTorB()) {
+    if(AuxUnitLayout.isTorB(mainObj)) {
       //auxUnit.bbox.y = 0;
       lengthUsed += auxUnit.bbox.w + unitGap;
     }
@@ -731,27 +808,27 @@ AuxUnitLayout.prototype.precomputeCoords = function (doForceUpdate) {
     }
   }
   // adjust the length, should be composed of outerMargin on the end, not unitGap
-  finalLengthUsed = finalLengthUsed - unitGap + this.getOuterMargin();
+  finalLengthUsed = finalLengthUsed - unitGap + AuxUnitLayout.getOuterMargin(mainObj);
 
-  this.lengthUsed = finalLengthUsed;
+  mainObj.lengthUsed = finalLengthUsed;
 };
 
-AuxUnitLayout.prototype.draw = function (context) {
-  for(var i=0; i < this.units.length; i++) {
-    var auxUnit = this.units[i];
+AuxUnitLayout.draw = function (mainObj, context) {
+  for(var i=0; i < mainObj.units.length; i++) {
+    var auxUnit = mainObj.units[i];
     if (auxUnit.isDisplayed) {
       // make each unit draw itself
-      auxUnit.draw(context);
+      getAuxUnitClass(auxUnit).draw(auxUnit, context);
     }
   }
 };
 
-AuxUnitLayout.prototype.isEmpty = function() {
-  return this.units.length == 0;
+AuxUnitLayout.isEmpty = function(mainObj) {
+  return mainObj.units.length == 0;
 };
 
-AuxUnitLayout.prototype.unitCount = function() {
-  return this.units.length;
+AuxUnitLayout.unitCount = function(mainObj) {
+  return mainObj.units.length;
 };
 
 /**
@@ -763,15 +840,15 @@ AuxUnitLayout.selectNextAvailable = function(node) {
   var resultLocation = "top";
 
   // start by adding on top if free
-  if(!top || top.isEmpty()) {
+  if(!top || AuxUnitLayout.isEmpty(top)) {
     resultLocation = "top";
   }
-  else if(!bottom || bottom.isEmpty()) {
+  else if(!bottom || AuxUnitLayout.isEmpty(bottom)) {
     resultLocation = "bottom";
   }
   else {
     // search for the side with the fewer units on it
-    if(top.unitCount() <= bottom.unitCount()) {
+    if(AuxUnitLayout.unitCount(top) <= AuxUnitLayout.unitCount(bottom)) {
       resultLocation = "top";
     }
     else {
@@ -781,34 +858,36 @@ AuxUnitLayout.selectNextAvailable = function(node) {
   return resultLocation;
 };
 
-AuxUnitLayout.prototype.resizeParent = function (length) {
-  if(this.isTorB()) {
-    if(this.parentNode.data('bbox').w < length) {
-      cy.trigger("noderesize.resizestart", ["centerright", this.parentNode]);
-      this.parentNode.data('bbox').w = length;
-      cy.trigger("noderesize.resizeend", ["centerright", this.parentNode]);
+AuxUnitLayout.resizeParent = function (mainObj, length) {
+  var parentNode = AuxUnitLayout.getParentNode(mainObj);
+  if(AuxUnitLayout.isTorB(mainObj)) {
+    if(parentNode.data('bbox').w < length) {
+      cy.trigger("noderesize.resizestart", ["centerright", parentNode]);
+      parentNode.data('bbox').w = length;
+      cy.trigger("noderesize.resizeend", ["centerright", parentNode]);
     }
   }
   else {
-    if(this.parentNode.data('bbox').h < length) {
-      cy.trigger("noderesize.resizestart", ["bottomcenter", this.parentNode]);
-      this.parentNode.data('bbox').h = length;
-      cy.trigger("noderesize.resizeend", ["bottomcenter", this.parentNode]);
+    if(parentNode.data('bbox').h < length) {
+      cy.trigger("noderesize.resizestart", ["bottomcenter", parentNode]);
+      parentNode.data('bbox').h = length;
+      cy.trigger("noderesize.resizeend", ["bottomcenter", parentNode]);
     }
   }
 };
 
-AuxUnitLayout.prototype.isTorB = function () {
-  return this.location == "top" || this.location == "bottom";
+AuxUnitLayout.isTorB = function (mainObj) {
+  return mainObj.location == "top" || mainObj.location == "bottom";
 };
 
-AuxUnitLayout.prototype.isLorR = function () {
-  return this.location == "left" || this.location == "right";
+AuxUnitLayout.isLorR = function (mainObj) {
+  return mainObj.location == "left" || mainObj.location == "right";
 };
 
-AuxUnitLayout.prototype.setParentMinLength = function () {
-  var parentLayouts = this.parentNode.data('auxunitlayouts');
-  switch(this.location) {
+AuxUnitLayout.setParentMinLength = function (mainObj) {
+  var parentNode = AuxUnitLayout.getParentNode(mainObj);
+  var parentLayouts = parentNode.data('auxunitlayouts');
+  switch(mainObj.location) {
     case "top":
       var compareVal = parentLayouts.bottom ? parentLayouts.bottom.lengthUsed : 0;
       break;
@@ -822,44 +901,44 @@ AuxUnitLayout.prototype.setParentMinLength = function () {
       var compareVal = parentLayouts.left ? parentLayouts.left.lengthUsed : 0;
       break;
   }
-  if(this.isTorB()) {
-    this.parentNode.data('resizeMinWidth', Math.max(this.lengthUsed, compareVal));
+  if(AuxUnitLayout.isTorB(mainObj)) {
+    parentNode.data('resizeMinWidth', Math.max(mainObj.lengthUsed, compareVal));
   }
   else {
-    this.parentNode.data('resizeMinHeight', Math.max(this.lengthUsed, compareVal));
+    parentNode.data('resizeMinHeight', Math.max(mainObj.lengthUsed, compareVal));
   }
 };
 
-AuxUnitLayout.prototype.getOuterMargin = function () {
-  if(typeof this.outerMargin !== "undefined" && this.outerMargin !== null) {
-    return this.outerMargin;
+AuxUnitLayout.getOuterMargin = function (mainObj) {
+  if(typeof mainObj.outerMargin !== "undefined" && mainObj.outerMargin !== null) {
+    return mainObj.outerMargin;
   }
   else {
     return AuxUnitLayout.outerMargin;
   }
 };
 
-AuxUnitLayout.prototype.getUnitGap = function () {
-  if(typeof this.unitGap !== "undefined" && this.unitGap !== null) {
-    return this.unitGap;
+AuxUnitLayout.getUnitGap = function (mainObj) {
+  if(typeof mainObj.unitGap !== "undefined" && mainObj.unitGap !== null) {
+    return mainObj.unitGap;
   }
   else {
     return AuxUnitLayout.unitGap;
   }
 };
 
-AuxUnitLayout.prototype.getAlwaysShowAuxUnits = function () {
-  if(typeof this.alwaysShowAuxUnits !== "undefined" && this.alwaysShowAuxUnits !== null) {
-    return this.alwaysShowAuxUnits;
+AuxUnitLayout.getAlwaysShowAuxUnits = function (mainObj) {
+  if(typeof mainObj.alwaysShowAuxUnits !== "undefined" && mainObj.alwaysShowAuxUnits !== null) {
+    return mainObj.alwaysShowAuxUnits;
   }
   else {
     return AuxUnitLayout.alwaysShowAuxUnits;
   }
 };
 
-AuxUnitLayout.prototype.getMaxUnitDisplayed = function () {
-  if(typeof this.maxUnitDisplayed !== "undefined" && this.maxUnitDisplayed !== null) {
-    return this.maxUnitDisplayed;
+AuxUnitLayout.getMaxUnitDisplayed = function (mainObj) {
+  if(typeof mainObj.maxUnitDisplayed !== "undefined" && mainObj.maxUnitDisplayed !== null) {
+    return mainObj.maxUnitDisplayed;
   }
   else {
     return AuxUnitLayout.maxUnitDisplayed;
@@ -869,30 +948,30 @@ AuxUnitLayout.prototype.getMaxUnitDisplayed = function () {
 /*
  *  Duplicate a layout. Doesn't copy the units attribute, reset it instead.
  */
-AuxUnitLayout.prototype.copy = function(newParent) {
-  var newLayout = new AuxUnitLayout(newParent);
+AuxUnitLayout.copy = function(mainObj, newParent) {
+  var newLayout = AuxUnitLayout.construct(newParent);
   // Copying the same reference to units would be inconsistent.
   // Duplicating owned units goes beyonnd the scope, because we need to assign
   // ids that are tied to the global cound of units of a node.
   // So duplicating units is something that should be properly done outside of this function.
   // TODO that is a bit dirty, find a nice modular way to arrange that
   newLayout.units = [];
-  newLayout.location = this.location;
-  newLayout.alignment = this.alignment;
+  newLayout.location = mainObj.location;
+  newLayout.alignment = mainObj.alignment;
   newLayout.parentNode = newParent;
-  newLayout.renderLengthCache = this.renderLengthCache;
-  newLayout.lengthUsed = this.lengthUsed;
-  if(typeof this.outerMargin !== "undefined") {
-    newLayout.outerMargin = this.outerMargin;
+  newLayout.renderLengthCache = mainObj.renderLengthCache;
+  newLayout.lengthUsed = mainObj.lengthUsed;
+  if(typeof mainObj.outerMargin !== "undefined") {
+    newLayout.outerMargin = mainObj.outerMargin;
   }
-  if(typeof this.unitGap !== "undefined") {
-    newLayout.unitGap = this.unitGap;
+  if(typeof mainObj.unitGap !== "undefined") {
+    newLayout.unitGap = mainObj.unitGap;
   }
-  if(typeof this.alwaysShowAuxUnits !== "undefined") {
-    newLayout.alwaysShowAuxUnits = this.alwaysShowAuxUnits;
+  if(typeof mainObj.alwaysShowAuxUnits !== "undefined") {
+    newLayout.alwaysShowAuxUnits = mainObj.alwaysShowAuxUnits;
   }
-  if(typeof this.maxUnitDisplayed !== "undefined") {
-    newLayout.maxUnitDisplayed = this.maxUnitDisplayed;
+  if(typeof mainObj.maxUnitDisplayed !== "undefined") {
+    newLayout.maxUnitDisplayed = mainObj.maxUnitDisplayed;
   }
   return newLayout;
 };

--- a/src/utilities/graph-utilities.js
+++ b/src/utilities/graph-utilities.js
@@ -66,7 +66,7 @@ graphUtilities.updateGraph = function(cyGraph) {
     // assign correct parents to info boxes
     var statesandinfos = node.data('statesandinfos');
     for (var j=0; j < statesandinfos.length; j++) {
-      classes.getAuxUnitClass(statesandinfos[j]).setParentRef(statesandinfos[i], node);
+      classes.getAuxUnitClass(statesandinfos[j]).setParentRef(statesandinfos[j], node);
     }
   });
 

--- a/src/utilities/graph-utilities.js
+++ b/src/utilities/graph-utilities.js
@@ -65,7 +65,7 @@ graphUtilities.updateGraph = function(cyGraph) {
     // assign correct parents to info boxes
     var statesandinfos = node.data('statesandinfos');
     for (var j=0; j < statesandinfos.length; j++) {
-      statesandinfos[j].parent = node;
+      statesandinfos[j].parent = node.id();
     }
   });
 

--- a/src/utilities/graph-utilities.js
+++ b/src/utilities/graph-utilities.js
@@ -6,6 +6,7 @@ var optionUtilities = require('./option-utilities');
 var options = optionUtilities.getOptions();
 var libs = require('./lib-utilities').getLibs();
 var jQuery = $ = libs.jQuery;
+var classes = require('./classes')
 
 function graphUtilities() {}
 
@@ -65,21 +66,21 @@ graphUtilities.updateGraph = function(cyGraph) {
     // assign correct parents to info boxes
     var statesandinfos = node.data('statesandinfos');
     for (var j=0; j < statesandinfos.length; j++) {
-      statesandinfos[j].parent = node.id();
+      classes.getAuxUnitClass(statesandinfos[j]).setParentRef(statesandinfos[i], node);
     }
   });
 
 
   this.refreshPaddings(); // Recalculates/refreshes the compound paddings
   cy.endBatch();
-  
+
   var layout = cy.layout({
     name: 'preset',
     positions: positionMap,
     fit: true,
     padding: 50
   });
-  
+
   // Check this for cytoscape.js backward compatibility
   if (layout && layout.run) {
     layout.run();
@@ -91,7 +92,7 @@ graphUtilities.updateGraph = function(cyGraph) {
   if (cy.edgeBendEditing && cy.edgeBendEditing('initialized')) {
     cy.edgeBendEditing('get').initBendPoints(cy.edges());
   }
-  
+
   $( document ).trigger( "updateGraphEnd" );
 };
 
@@ -123,7 +124,7 @@ graphUtilities.calculatePaddings = function(paddingPercent) {
 };
 
 graphUtilities.recalculatePaddings = graphUtilities.refreshPaddings = function() {
-  // this.calculatedPaddings is not working here 
+  // this.calculatedPaddings is not working here
   // TODO: replace this reference with this.calculatedPaddings once the reason is figured out
   graphUtilities.calculatedPaddings = this.calculatePaddings();
   return graphUtilities.calculatedPaddings;

--- a/src/utilities/sbgnml-to-json-converter.js
+++ b/src/utilities/sbgnml-to-json-converter.js
@@ -174,7 +174,7 @@ var sbgnmlToJson = {
       var info = {};
 
       if (glyph.class_ === 'unit of information') {
-        var unitOfInformation = new classes.UnitOfInformation();
+        var unitOfInformation = classes.UnitOfInformation.construct();
         if(glyph.entity) {
           // change the parent class according to its true class of biological activity
           switch(glyph.entity.name) {
@@ -185,8 +185,6 @@ var sbgnmlToJson = {
             case 'perturbation':          parent.class = "BA perturbing agent"; break;
             case 'complex':               parent.class = "BA complex"; break;
           }
-          unitOfInformation.shapeFn = libs.cytoscape.sbgn.AfShapeFn;
-          unitOfInformation.shapeArgsFn = libs.cytoscape.sbgn.AfShapeArgsFn;
         }
 
         unitOfInformation.id = glyph.id || undefined;
@@ -194,7 +192,7 @@ var sbgnmlToJson = {
           'text': (glyph.label && glyph.label.text) || undefined
         };
         unitOfInformation.bbox = self.stateAndInfoBboxProp(glyph, parentBbox);
-        unitOfInformation.setAnchorSide();
+        classes.UnitOfInformation.setAnchorSide(unitOfInformation);
         stateAndInfoArray.push(unitOfInformation);
       } else if (glyph.class_ === 'state variable') {
         var stateVariable = new classes.StateVariable();
@@ -203,7 +201,7 @@ var sbgnmlToJson = {
         stateVariable.state.value = (state && state.value) || undefined;
         stateVariable.state.variable = (state && state.variable) || undefined;
         stateVariable.bbox = self.stateAndInfoBboxProp(glyph, parentBbox);
-        stateVariable.setAnchorSide();
+        classes.StateVariable.setAnchorSide(stateVariable);
         stateAndInfoArray.push(stateVariable);
       }
     }

--- a/src/utilities/sbgnml-to-json-converter.js
+++ b/src/utilities/sbgnml-to-json-converter.js
@@ -195,7 +195,7 @@ var sbgnmlToJson = {
         classes.UnitOfInformation.setAnchorSide(unitOfInformation);
         stateAndInfoArray.push(unitOfInformation);
       } else if (glyph.class_ === 'state variable') {
-        var stateVariable = new classes.StateVariable();
+        var stateVariable = classes.StateVariable.construct();
         stateVariable.id = glyph.id || undefined;
         var state = glyph.state;
         stateVariable.state.value = (state && state.value) || undefined;


### PR DESCRIPTION
State variables and units of information objects in SBGNViz can not be serialized to JSON objects (that breaks CWC) because of 2 main reasons:

1.  They include references to their parent nodes and the parent nodes include reference to them. That creates a circular reference.
2. They are instances of complex JS objects that includes prototyping.

The changes proposed by this PR are made to solve these problems. This PR required making other PRs (with much smaller changes) for chise.js, newt and iVis-at-Bilkent/cytoscape.js. I will create that PRs after this one.

Information about how to use the changed classes are given at the top of ```classes.js``` file as a comment.