### PR TITLE
Made default properties refactoring and moved some stuff from chise level to sbgnviz level

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,10 +207,40 @@ Ends any spinner having a css class with the given name. Requires 'fontawesome.c
 
 `instance.elementUtilities`
 General and sbgn specific utilities for cytoscape elements. These are exposed for the users who builds an extension
-library of sbgnviz. Most users will not need to use this. It includes the followings.
+library of sbgnviz. Most users will not need to use this. It includes the followings:
 
+* `getDefaultProperties(sbgnclass)` Access the default properties for elements of given sbgnclass. If sbgnclass parameter is not defined it returns the whole map where the default properties are mapped to sbgnclasses. These properties are considered upon element creation. The special fields are the followings.<br>
+   'width': The default width<br>
+   'height': The default height<br>
+   'font-size': The default font size<br>
+   'font-family': The default font family<br>
+   'font-style': The default font style<br>
+   'font-weight': The default font weight<br>
+   'background-color': The default background color<br>
+   'background-opacity': The default background opacity<br>
+   'border-width': The default border width<br>
+   'border-color': The default border color
+* `setDefaultProperties(sbgnclass, props)` Updates the default properties map of given sbgnclass by the given properties.
  * `getTopMostNodes(nodes)` This method returns the nodes non of whose ancestors is not in given nodes.
  * `allHaveTheSameParent(nodes)` This method checks if all of the given nodes have the same parent assuming that the size of  nodes is not 0.
+ * `isValidParent(nodeClass, parentClass)` Returns if the elements with the given parent class can be parent of the elements with the given node class.
+ * `getCommonProperty(nodes, width, height, useAspectRatio)` Get common properties of given elements. Returns null if the given element list is empty or the property is not common for all elements.
+    dataOrCss parameter specify whether to check the property on data or css. The default value for it is data. If propertyName parameter is given as a function instead of a string representing the
+    property name then use what that function returns.
+ * `trueForAllElements(elements, fcn)` Returns if the function returns a truthy value for all of the given elements.
+ * `canHaveSBGNCardinality(ele)` Returns whether the given element or elements with the given class can have sbgncardinality.
+ * `canHaveSBGNLabel(ele)` Returns whether the given element or elements with the given class can have sbgnlabel.
+ * `isBiologicalActivity(ele)` Returns whether the given elements class is a subtype of biological activity. Parameter would correspond to the class itself as well.
+ * `canHaveUnitOfInformation(ele)` Returns whether the given element or elements with the given class have unit of information.
+ * `canHaveStateVariable(ele)` Returns whether the given element or elements with the given class have state variable.
+ * `mustBeSquare(ele)` Returns whether the given element or elements with the given class should have the same width and height.
+ * `someMustNotBeSquare(ele)` Returns whether the given element or elements with the given class must not be in square shape.
+ * `canBeCloned(ele)` Returns whether the given element or elements with the given class can be cloned.
+ * `canBeMultimer(ele)` Returns whether the given element or elements with the given class can be multimer.
+ * `isEPNClass(ele)` Returns whether the given class is an EPN class or the given element is an EPN.
+ * `isPNClass(ele)` Returns whether the given class is an PN class or the given element is an PN.
+ * `isLogicalOperator(ele)` Returns whether the given class is a logical operator class or the given element is a logical operator.
+ * `convenientToEquivalence(ele)` Returns whether the given class or the class of the given element is an equivalance class.
  * `moveNodes(positionDiff, nodes)` This method moves given nodes by the given position difference.
  * `convertToModelPosition(renderedPosition)` This method calculates the modal position of the given rendered position by considering current the pan and zoom level of the graph.
  * `getProcessesOfSelected()` Returns the processes of the selected nodes.

--- a/src/sbgn-extensions/sbgn-cy-instance-factory.js
+++ b/src/sbgn-extensions/sbgn-cy-instance-factory.js
@@ -268,14 +268,9 @@ module.exports = function () {
 	          .css({
 	            'text-valign': 'center',
 	            'text-halign': 'center',
-	            'border-width': 1.25,
-	            'border-color': '#555',
-	            'background-color': '#ffffff',
-	            'background-opacity': 0.5,
 	            'text-opacity': 1,
 	            'opacity': 1,
-	            'padding': 0,
-	            'text-wrap': 'wrap'
+	            'padding': 0
 	          })
 	          .selector("node[class]")
 	          .css({
@@ -285,10 +280,92 @@ module.exports = function () {
 	            'content': function (ele) {
 	              return elementUtilities.getElementContent(ele);
 	            },
-	            'font-size': function (ele) {
-	              return elementUtilities.getLabelTextSize(ele);
-	            },
-	          })
+							'font-size': function (ele) {
+			          // If node labels are expected to be adjusted automatically or element cannot have label
+			          // or ele.data('font-size') is not defined return elementUtilities.getLabelTextSize()
+								// else return ele.data('font-size')
+			          var opt = options.adjustNodeLabelFontSizeAutomatically;
+			          var adjust = typeof opt === 'function' ? opt() : opt;
+
+			          if (!adjust && ele.data('font-size') != undefined) {
+			            return ele.data('font-size');
+			          }
+
+			          return elementUtilities.getLabelTextSize(ele);
+			        }
+			      })
+			      .selector("node[class][font-family]")
+			      .style({
+			        'font-family': function( ele ) {
+								return ele.data('font-family');
+							}
+			      })
+			      .selector("node[class][font-style]")
+			      .style({
+			        'font-style': function( ele ) {
+								return ele.data('font-style')
+							}
+			      })
+			      .selector("node[class][font-weight]")
+			      .style({
+			        'font-weight': function( ele ) {
+								return ele.data('font-weight');
+							}
+			      })
+			      .selector("node[class][color]")
+			      .style({
+			        'color': function( ele ) {
+								return ele.data('color');
+							}
+			      })
+			      .selector("node[class][background-color]")
+			      .style({
+			        'background-color': function( ele ) {
+								return ele.data('background-color');
+							}
+			      })
+			      .selector("node[class][background-opacity]")
+			      .style({
+			        'background-opacity': function( ele ) {
+								return ele.data('background-opacity');
+							}
+			      })
+			      .selector("node[class][border-width]")
+			      .style({
+			        'border-width': function( ele ) {
+								return ele.data('border-width');
+							}
+			      })
+			      .selector("node[class][border-color]")
+			      .style({
+			        'border-color': function( ele ) {
+								return ele.data('border-color');
+							}
+			      })
+			      .selector("node[class][text-wrap]")
+			      .style({
+			        'text-wrap': function( ele ) {
+								return ele.data('text-wrap');
+							}
+			      })
+						.selector("edge[class][line-color]")
+			      .style({
+			        'line-color': function( ele ) {
+								return ele.data('line-color');
+							},
+			        'source-arrow-color': function( ele ) {
+								return ele.data('line-color');
+							},
+			        'target-arrow-color': function( ele ) {
+								return ele.data('line-color');
+							}
+			      })
+			      .selector("edge[class][width]")
+			      .style({
+			        'width': function( ele ) {
+								return ele.data('width');
+							}
+			      })
 	          .selector("node[class='association'],[class='dissociation'],[class='and'],[class='or'],[class='not'],[class='process'],[class='omitted process'],[class='uncertain process']")
 	          .css({
 	            'shape-polygon-points': function(ele) {
@@ -345,8 +422,6 @@ module.exports = function () {
 	          })
 	          .selector("node[class='submap']")
 	          .css({
-	            'border-width': 2.25,
-	            'background-opacity': 0,
 	            'text-valign': 'bottom',
 	            'text-halign': 'center',
 	            'text-margin-y' : -1 * options.extraCompartmentPadding,
@@ -429,10 +504,8 @@ module.exports = function () {
 	          .selector("edge")
 	          .css({
 	            'curve-style': 'bezier',
-	            'line-color': '#555',
 	            'target-arrow-fill': 'hollow',
 	            'source-arrow-fill': 'hollow',
-	            'width': 1.25,
 	            'target-arrow-color': '#555',
 	            'source-arrow-color': '#555',
 	            'text-border-color': function (ele) {

--- a/src/utilities/option-utilities-factory.js
+++ b/src/utilities/option-utilities-factory.js
@@ -30,6 +30,12 @@ module.exports = function () {
     improveFlow: function () {
         return true;
     },
+    // Whether to adjust node label font size automatically.
+    // If this option return false do not adjust label sizes according to node height uses node.data('font-size')
+    // instead of doing it.
+    adjustNodeLabelFontSizeAutomatically: function() {
+      return true;
+    },
     // extra padding for compartment and complexes
     extraCompartmentPadding: 10,
     extraComplexPadding: 10,

--- a/src/utilities/sbgnml-to-json-converter-factory.js
+++ b/src/utilities/sbgnml-to-json-converter-factory.js
@@ -4,13 +4,19 @@ var libUtilities = require('./lib-utilities');
 var classes = require('./classes');
 
 module.exports = function () {
-  var elementUtilities, graphUtilities;
+  var elementUtilities, graphUtilities, handledElements;
 
   function sbgnmlToJson (param) {
     optionUtilities = param.optionUtilities;
     options = optionUtilities.getOptions();
     elementUtilities = param.elementUtilities;
     graphUtilities = param.graphUtilities;
+
+    handledElements = {};
+
+    elementUtilities.elementTypes.forEach( function( type ) {
+      handledElements[ type ] = true;
+    } );
   }
 
   sbgnmlToJson.insertedNodes = {};
@@ -276,6 +282,17 @@ module.exports = function () {
     self.addParentInfoToNode(ele, nodeObj, parent, compartments);
     // add language info, this will always be the mapType
     nodeObj.language = elementUtilities.mapType;
+    // add default properties of the node type to element data
+    // these props would be overriden by style properties of element
+    // stored in the file
+    var defaultProps = elementUtilities.getDefaultProperties( nodeObj.class );
+
+    Object.keys( defaultProps ).forEach( function( prop ) {
+      // skip width and height
+      if ( prop !== 'width' && prop !== 'height' ) {
+        nodeObj[ prop ] = defaultProps[ prop ];
+      }
+    } );
 
     // add clone information
     if (ele.clone) {
@@ -416,7 +433,7 @@ module.exports = function () {
 
   sbgnmlToJson.traverseNodes = function (ele, jsonArray, parent, compartments) {
     var elId = ele.id;
-    if (!elementUtilities.handledElements[ele.class_]) {
+    if (!handledElements[ele.class_]) {
       return;
     }
     this.insertedNodes[elId] = true;
@@ -537,7 +554,7 @@ module.exports = function () {
   };
 
   sbgnmlToJson.addCytoscapeJsEdge = function (ele, jsonArray, xmlObject) {
-    if (!elementUtilities.handledElements[ele.class_]) {
+    if (!handledElements[ele.class_]) {
       return;
     }
 


### PR DESCRIPTION
This PR should be considered together with https://github.com/iVis-at-Bilkent/newt/pull/372 and https://github.com/iVis-at-Bilkent/chise.js/pull/118. Note that since the branch is based on unstable the problem in https://github.com/iVis-at-Bilkent/newt/issues/371 is seen but it is not related to this PR. The followings are the list of main changes:

- Defined default properties in Sbgnviz instead of Chise with a new implementation.
- Provided api functions in element utilities to get and set default properties.
- Used the same default properties for initial graph elements and the new ones (as long as they are not updated).
- Since default properties has many common things for element types tried to reduce the code duplications by generalizing them and extending the generic defaults where applicable.
- Defined ``adjustNodeLabelFontSizeAutomatically`` option in Sbgnviz level instead of Chise level because it is actually about rendering.
- Moved element specific getter functions to Sbgnviz level from Chise level.