### PR TITLE
Sbgn renderer refactoring 

### DIFF
--- a/src/sbgn-extensions/sbgn-cy-renderer.js
+++ b/src/sbgn-extensions/sbgn-cy-renderer.js
@@ -695,6 +695,9 @@ module.exports = function () {
     "oldCompartment": $$.sbgn.drawRoundRectangle
   };
 
+  // To define an extra drawing for the node that is rendered at the very end,
+  // even after the node background image is drawn.
+  // E.g. cross lines of "source and sink" nodes.
   $$.sbgn.extraDraw = {
     "source and sink": $$.sbgn.drawCrossLine
   };

--- a/src/sbgn-extensions/sbgn-cy-renderer.js
+++ b/src/sbgn-extensions/sbgn-cy-renderer.js
@@ -1009,6 +1009,64 @@ module.exports = function () {
     return []; // if nothing
   };
 
+  //this function gives the intersections of any line with the upper half of perturbing agent
+  $$.sbgn.perturbingAgentIntersectLine = function (
+          x1, y1, x2, y2, nodeX, nodeY, width, height, padding) {
+
+    var halfWidth = width / 2;
+    var halfHeight = height / 2;
+
+    // Check intersections with straight line segments
+    var straightLineIntersections = [];
+
+    // Top segment, left to right
+    {
+      var topStartX = nodeX - halfWidth - padding;
+      var topStartY = nodeY - halfHeight - padding;
+      var topEndX = nodeX + halfWidth + padding;
+      var topEndY = topStartY;
+
+      var intersection = cyMath.finiteLinesIntersect(
+              x1, y1, x2, y2, topStartX, topStartY, topEndX, topEndY, false);
+
+      if (intersection.length > 0) {
+        straightLineIntersections = straightLineIntersections.concat(intersection);
+      }
+    }
+
+    // Right segment, top to bottom
+    {
+      var rightStartX = nodeX + halfWidth + padding;
+      var rightStartY = nodeY - halfHeight - padding;
+      var rightEndX = rightStartX - halfWidth/2;
+      var rightEndY = nodeY + padding;
+
+      var intersection = cyMath.finiteLinesIntersect(
+              x1, y1, x2, y2, rightStartX, rightStartY, rightEndX, rightEndY, false);
+
+      if (intersection.length > 0) {
+        straightLineIntersections = straightLineIntersections.concat(intersection);
+      }
+    }
+
+    // Left segment, top to bottom
+    {
+      var leftStartX = nodeX - halfWidth - padding;
+      var leftStartY = nodeY - halfHeight - padding;
+      var leftEndX = leftStartX + halfWidth/2;
+      var leftEndY = nodeY + padding;
+
+      var intersection = cyMath.finiteLinesIntersect(
+              x1, y1, x2, y2, leftStartX, leftStartY, leftEndX, leftEndY, false);
+
+      if (intersection.length > 0) {
+        straightLineIntersections = straightLineIntersections.concat(intersection);
+      }
+    }
+
+    return straightLineIntersections;
+  };
+
   //this function gives the intersections of any line with a round rectangle
   $$.sbgn.roundRectangleIntersectLine = function (
           x1, y1, x2, y2, nodeX, nodeY, width, height, cornerRadius, padding) {
@@ -1231,10 +1289,8 @@ module.exports = function () {
               infoBoxWidth / 4);
         }
         else if (node.data("class") == "BA perturbing agent"){
-          var points = $$.sbgn.generatePerturbingAgentPoints();
-          currIntersections = cyMath.polygonIntersectLine(
-            x, y, points, coord.x, coord.y, infoBoxWidth / 2,
-            infoBoxHeight / 2, padding );
+          currIntersections = $$.sbgn.perturbingAgentIntersectLine(x, y, centerX, centerY,
+              coord.x, coord.y, infoBoxWidth, infoBoxHeight, padding);
         }
         else {
           currIntersections = $$.sbgn.roundRectangleIntersectLine(x, y, centerX, centerY,


### PR DESCRIPTION
The shapes defined in sbgn renderer should have 3 functions to describe how the shape should be drawn (``draw``), where the edges should intersect the shape (``intersectLine``) and whether a point is inside the shape or not (``checkPoint``). However, defining these functions for all of the shapes defined in sbgn renderer is causing a lot of code replications. To overcome this issue I created functions called ``generateDrawFcn``, ``generateIntersectLineFcn`` and ``generateCheckPointFcn`` that can generate related functions for any node type given the basic features of the node. For example ``generateDrawFcn`` takes the following parameters:

- ``plainDrawFcn`` defines how the plain shape (like only rounded rectangle for macromolecules does not includes infoboxes, multimers, clone markers etc.) should be rendered.
- ``extraDrawFcn`` if defined used to finish the drawing with an extra line etc. The only use case so far is the cross lines of ``source and sink`` nodes.
- ``canBeMultimer`` whether a member of the node type can be a multimer.
- ``cloneMarkerFcn`` how to draw clone marker of the node if needed.
- ``canHaveInfoBox`` whether a member of the node type can carry infoboxes.
- ``multimerPadding`` the same of how it was already used in renderer.

Using these parameters a specific ``draw`` function is generated for each node shape. The same is done for ``intersectLine`` and ``checkPoint`` as well. I think that getting rid of these code replications would be useful in various cases. Adding new node shapes would be easier (we will need new node shapes at least for the SIF palette) and can be done in a more consistent way. Also updates can be done with less effort and again with a higher consistency since they will mostly be updated only in the generator functions. 

As an example of consistency issue clonemarker function call of simple chemical is currently done with different parameters than others (macromolecule, nuclecic acid feature, complex). Both logically and in terms of the results looks like that how clonemarker of simple chemical is called is the correct way. Therefore, in the generator function I used that way. 

The following is how the currently clone markers are rendered for the mentioned node types (taken from unstable branch deployment at http://ivis.cs.bilkent.edu.tr/)

<img width="978" alt="screen shot 2018-08-15 at 3 40 52 pm" src="https://user-images.githubusercontent.com/6534865/44177200-a3051c00-a0a1-11e8-9f41-c52305afd953.png">

The following is how they are rendered in this PR

<img width="929" alt="screen shot 2018-08-15 at 3 43 38 pm" src="https://user-images.githubusercontent.com/6534865/44177274-055e1c80-a0a2-11e8-8287-d3692af411c5.png">

As it can be seen by the images currently the clonemarkers (other than simple chemical clone markers) are overflowing to the node borders since they are rendered with wrong parameters but they do not overflow in this PR. However, when the related parameters are fixed and the clone markers are rendered at the correct location a problem about their radius become visible (little white spaces between the borders and the clone markers). I suppose it is something independent of this PRs context to fix.

By the PR lines of code in sbgn renderer is decreased to 1447 from 1850.

I tested by comparing each of the sample networks from the running code of PR and the deployed unstable. Also, created any node type with any possible features and checked if they are rendered as expected, if they are intersecting edges as expected and if they can be selected as expected when they are clicked.