### PR TITLE
Changes for cytoscape.js 3.2.16 upgrade

### DIFF
--- a/src/sbgn-extensions/sbgn-cy-renderer.js
+++ b/src/sbgn-extensions/sbgn-cy-renderer.js
@@ -15,6 +15,15 @@ var classes = require('../utilities/classes');
 module.exports = function () {
   var $$ = cytoscape;
 
+  /*
+  * Taken from cytoscape.js and modified so that it can be utilized from sbgnviz
+  * in a flexable way. It is needed because the sbgnviz shapes would need to stroke
+  * border more than once as they would have infoboxes, multimers etc.
+  * Extends the style properties of node with the given ones then strokes the border.
+  * Would needed to be slightly updated during cytoscape upgrades if related function in
+  * Cytoscape.js is updated. Information about where is the related function is located
+  * can be found in the file that list the changes done in ivis cytoscape fork.
+  */
   $$.sbgn.drawBorder = function({ context, node, borderWidth, borderColor, borderStyle, borderOpacity }) {
 
     borderWidth = borderWidth || ( node && parseFloat( node.css( 'border-width' ) ) );

--- a/src/utilities/classes.js
+++ b/src/utilities/classes.js
@@ -95,13 +95,7 @@ AuxiliaryUnit.copy = function (mainObj, cy, existingInstance, newParent, newId) 
 AuxiliaryUnit.draw = function(mainObj, cy, context) {
   var unitClass = getAuxUnitClass(mainObj);
   var coords = unitClass.getAbsoluteCoord(mainObj, cy);
-  var parent = getAuxUnitClass(mainObj).getParent(mainObj, cy);
-  if (mainObj.dashed === true || parent.hasClass('cy-expand-collapse-collapsed-node')) {
-    context.setLineDash([2,2]);
-  }
-  else {
-    context.setLineDash([]);
-  }
+
   unitClass.drawShape(mainObj, cy, context, coords.x, coords.y);
   if (unitClass.hasText(mainObj, cy)) {
     unitClass.drawText(mainObj, cy, context, coords.x, coords.y);
@@ -394,8 +388,8 @@ StateVariable.drawShape = function(mainObj, cy, context, x, y) {
   context.fillStyle = tmp_ctxt;
 
   var parent = getAuxUnitClass(mainObj).getParent(mainObj, cy);
-  if(parent.pstyle( 'border-width' ).pfValue > 0)
-    context.stroke();
+  var borderStyle = mainObj.dashed ? 'dashed' : undefined;
+  cytoscape.sbgn.drawBorder( { context, node: parent, borderStyle } );
 };
 
 StateVariable.create = function(parentNode, cy, value, variable, bbox, location, position, index) {
@@ -488,10 +482,10 @@ UnitOfInformation.drawShape = function(mainObj, cy, context, x, y) {
   context.fillStyle = UnitOfInformation.defaultBackgroundColor;
   context.fill();
   context.fillStyle = tmp_ctxt;
-  
+
   var parent = getAuxUnitClass(mainObj).getParent(mainObj, cy);
-  if(parent.pstyle( 'border-width' ).pfValue > 0)
-    context.stroke();
+  var borderStyle = mainObj.dashed ? 'dashed' : undefined;
+  cytoscape.sbgn.drawBorder( { context, node: parent, borderStyle } );
 };
 
 /**


### PR DESCRIPTION
Made changes for cytoscape.js upgrade, so should be merged together with the related PR in ivis fork of Cytoscape.js. Also used 'barrel' and 'bottomroundrectangle' shapes of cytoscape as the base shapes of 'compartment' and 'nucleic acid feature' respectively. However, old draw function of nucleic acid feature is still remaining with a different name since it is needed for drawing clone markers of macromolecule and nucleic acid feature shapes. Needed it because 'bottomroundrectangle' shape did not work well for clonemarker. It was giving the following result:

<img width="182" alt="screen shot 2018-08-30 at 4 57 04 pm" src="https://user-images.githubusercontent.com/6534865/44885481-e6e94b00-ac75-11e8-93e5-e1e3fd849534.png">


Also considered using 'cutrectangle' as the base shape of complexes but it did not render as expected when the shape dimensions are very small. The most visible case was the "BA Complex" node since the sizes of complex unit of information there is small. You can see the [this fiddle](http://jsfiddle.net/5379tysh/7/) to see how it looks for small sizes. You can play with width and height parameters in js code to render the shape in different sizes.