### PR TITLE
Add optional parameters to saveAsPng, saveAsJpg, saveAsSvg

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,17 +193,18 @@ As this percentadge takes the given paddingPercent or compoundPadding option.
 `instance.recalculatePaddings()`
 Recalculates/refreshes the compound paddings. Aliases `instance.refreshPaddings()`.
 
-`instance.saveAsPng(filename)`
+`instance.saveAsPng(filename, scale, bg, maxWidth, maxHeight)`
 Exports the current graph to a png file. The name of the file is determined by the filename parameter which is
-'network.png' by default.
+'network.png' by default. If maxWidth/maxHeight parameter is defined, then scale is ignored. bg is background color. 
 
-`instance.saveAsJpg(filename)`
+`instance.saveAsJpg(filename, scale, bg, maxWidth, maxHeight, quality)`
 Exports the current graph to a jpg file. The name of the file is determined by the filename parameter which is
-'network.jpg' by default.
+'network.jpg' by default. If maxWidth/maxHeight parameter is defined, then scale is ignored. bg is background color. 
+quality specifies the quality of the image from 0 to 1.
 
-`instance.saveAsSVG(filename)`
+`instance.saveAsSVG(filename, scale, bg, maxWidth, maxHeight)`
 Exports the current graph to a svg file. The name of the file is determined by the filename parameter which is
-'network.svg' by default.
+'network.svg' by default. If maxWidth/maxHeight parameter is defined, then scale is ignored. bg is background color.
 
 `instance.loadFile(file, convertFcn, callback1, callback2, callback3, callback4)`
 

--- a/src/utilities/file-utilities-factory.js
+++ b/src/utilities/file-utilities-factory.js
@@ -102,11 +102,18 @@ module.exports = function () {
 
  fileUtilities.loadXMLDoc = loadXMLDoc;
 
- fileUtilities.saveAsPng = function(filename, scale=3, bg, maxWidth, maxHeight) {
-   var pngContent = cy.png({
-     scale: scale, full: true, bg: bg, 
-     maxWidth: maxWidth, maxHeight:maxHeight
-   });
+ fileUtilities.saveAsPng = function(filename, scale, bg, maxWidth, maxHeight) {
+   if(maxWidth || maxHeight) {
+     var pngContent = cy.png({
+       full: true, bg: bg, 
+       maxWidth: maxWidth, maxHeight: maxHeight
+     });
+   }
+   else {
+     var pngContent = cy.png({
+       scale: scale || 3, full: true, bg: bg
+     });
+   }
 
    // this is to remove the beginning of the pngContent: data:img/png;base64,
    var b64data = pngContent.substr(pngContent.indexOf(",") + 1);
@@ -120,13 +127,21 @@ module.exports = function () {
    saveAs(b64toBlob(b64data, "image/png"), filename || "network.png");
  };
 
- fileUtilities.saveAsJpg = function(filename, scale=3, bg, maxWidth, maxHeight, quality) {
-   var jpgContent = cy.jpg({
-    scale: scale, full: true, bg: bg, 
-    maxWidth: maxWidth, maxHeight: maxHeight, 
-    quality: quality
-  });
-
+ fileUtilities.saveAsJpg = function(filename, scale, bg, maxWidth, maxHeight, quality) {
+   if(maxWidth || maxHeight) {
+     var jpgContent = cy.jpg({
+       full: true, bg: bg, 
+       maxWidth: maxWidth, maxHeight: maxHeight, 
+       quality: quality
+     });
+   }
+   else {
+     var jpgContent = cy.jpg({
+       scale: scale || 3, full: true, bg: bg, 
+       quality: quality
+     });
+   }
+   
    // this is to remove the beginning of the pngContent: data:img/png;base64,
    var b64data = jpgContent.substr(jpgContent.indexOf(",") + 1);
 

--- a/src/utilities/file-utilities-factory.js
+++ b/src/utilities/file-utilities-factory.js
@@ -154,8 +154,16 @@ module.exports = function () {
    saveAs(b64toBlob(b64data, "image/jpg"), filename || "network.jpg");
  };
 
- fileUtilities.saveAsSvg = function(filename, scale=1, bg) {
-   var svgContent = cy.svg({scale: scale, full: true, bg: bg});
+ fileUtilities.saveAsSvg = function(filename, scale, bg, maxWidth, maxHeight) {
+   if (maxWidth || maxHeight) {
+     var svgContent = cy.svg({
+       full: true, bg: bg, 
+       maxWidth: maxWidth, maxHeight: maxHeight
+     });
+   }
+   else {
+     var svgContent = cy.svg({scale: scale || 1, full: true, bg: bg});
+   }
    saveAs(new Blob([svgContent], {type:"image/svg+xml;charset=utf-8"}), filename || "network.svg");
  };
 

--- a/src/utilities/file-utilities-factory.js
+++ b/src/utilities/file-utilities-factory.js
@@ -123,7 +123,7 @@ module.exports = function () {
  fileUtilities.saveAsJpg = function(filename, scale=3, bg, maxWidth, maxHeight, quality) {
    var jpgContent = cy.jpg({
     scale: scale, full: true, bg: bg, 
-    maxWidth: maxWidth, maxHeight, maxHeight, 
+    maxWidth: maxWidth, maxHeight: maxHeight, 
     quality: quality
   });
 

--- a/src/utilities/file-utilities-factory.js
+++ b/src/utilities/file-utilities-factory.js
@@ -102,38 +102,45 @@ module.exports = function () {
 
  fileUtilities.loadXMLDoc = loadXMLDoc;
 
- fileUtilities.saveAsPng = function(filename) {
-   var pngContent = cy.png({scale: 3, full: true});
+ fileUtilities.saveAsPng = function(filename, scale=3, bg, maxWidth, maxHeight) {
+   var pngContent = cy.png({
+     scale: scale, full: true, bg: bg, 
+     maxWidth: maxWidth, maxHeight:maxHeight
+   });
 
    // this is to remove the beginning of the pngContent: data:img/png;base64,
    var b64data = pngContent.substr(pngContent.indexOf(",") + 1);
 
    // lower quality when response is empty
    if(!b64data || b64data === ""){
-     pngContent = cy.png({maxWidth: 15000, maxHeight: 15000, full: true});
+     pngContent = cy.png({maxWidth: 15000, maxHeight: 15000, full: true, bg: bg});
      b64data = pngContent.substr(pngContent.indexOf(",") + 1);
    }
 
    saveAs(b64toBlob(b64data, "image/png"), filename || "network.png");
  };
 
- fileUtilities.saveAsJpg = function(filename) {
-   var jpgContent = cy.jpg({scale: 3, full: true});
+ fileUtilities.saveAsJpg = function(filename, scale=3, bg, maxWidth, maxHeight, quality) {
+   var jpgContent = cy.jpg({
+    scale: scale, full: true, bg: bg, 
+    maxWidth: maxWidth, maxHeight, maxHeight, 
+    quality: quality
+  });
 
    // this is to remove the beginning of the pngContent: data:img/png;base64,
    var b64data = jpgContent.substr(jpgContent.indexOf(",") + 1);
 
    // lower quality when response is empty
    if(!b64data || b64data === ""){
-     jpgContent = cy.jpg({maxWidth: 15000, maxHeight: 15000, full: true});
+     jpgContent = cy.jpg({maxWidth: 15000, maxHeight: 15000, full: true, bg: bg});
      b64data = jpgContent.substr(jpgContent.indexOf(",") + 1);
    }
 
    saveAs(b64toBlob(b64data, "image/jpg"), filename || "network.jpg");
  };
 
- fileUtilities.saveAsSvg = function(filename) {
-   var svgContent = cy.svg({scale: 1, full: true});
+ fileUtilities.saveAsSvg = function(filename, scale=1, bg) {
+   var svgContent = cy.svg({scale: scale, full: true, bg: bg});
    saveAs(new Blob([svgContent], {type:"image/svg+xml;charset=utf-8"}), filename || "network.svg");
  };
 


### PR DESCRIPTION
Adds parameters which are available in cytoscape but not sbgnviz.
They should be completely optional and shouldn't change existing behaviour. 

Note that saving as SVG with background-color do not work (Hasan confirmed it).
