### PR TITLE
Fix for getting sbgnml file map properties

### DIFF
--- a/src/utilities/main-utilities-factory.js
+++ b/src/utilities/main-utilities-factory.js
@@ -670,8 +670,10 @@ module.exports = function () {
    */
 mainUtilities.getMapProperties = function() {
   if( elementUtilities.fileFormat !== undefined){
-    if( elementUtilities.fileFormat == 'sbgnml')
-       this.showNodesSmart
+    if( elementUtilities.fileFormat == 'sbgnml'){
+      //this.showNodesSmart
+      return sbgnmlToJson.mapPropertiesToObj();
+    }
     else if( elementUtilities.fileFormat == 'nwt' )
       return nwtToJson.mapPropertiesToObj();
     else if( elementUtilities.fileFormat == 'td')


### PR DESCRIPTION
Fix related to the newt issue https://github.com/iVis-at-Bilkent/newt/issues/689. Now the sbgnml files properties are being returned correctly.

 In mainUtilities.getMapProperties in 'sbgnml' format conditional branch there exist an incorrect function call. The function is not called, but do we need to call this function in a proper way? 

```diff
mainUtilities.getMapProperties = function() {
  if( elementUtilities.fileFormat !== undefined){
    if( elementUtilities.fileFormat == 'sbgnml'){
-      this.showNodesSmart
+      return sbgnmlToJson.mapPropertiesToObj();
    }
    else if( 